### PR TITLE
Mutable component

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -40,6 +40,13 @@ let package = Package(
             swiftSettings: swiftSettings()
         ),
         .testTarget(
+            name: "DITests",
+            dependencies: [
+                "DI",
+            ],
+            swiftSettings: swiftSettings()
+        ),
+        .testTarget(
             name: "DIMacrosTests",
             dependencies: [
                 .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax"),

--- a/Sources/DI/ComponentProtocol.swift
+++ b/Sources/DI/ComponentProtocol.swift
@@ -17,6 +17,11 @@ extension Component {
         }
     }
 
+    @inlinable
+    public func _get<I>(_ key: Key<I>, with components: [any Component]) -> I {
+        return container.get(key, with: components)
+    }
+
     public mutating func initContainer(parent: (any DI.Component)?) {
         if let parent {
             assertRequirements(Self.requirements, container: parent.container)

--- a/Sources/DI/ComponentProtocol.swift
+++ b/Sources/DI/ComponentProtocol.swift
@@ -1,10 +1,40 @@
 public protocol Component: Sendable {
     var container: Container { get set }
+    var parents: [any Component] { get set }
+    static func buildMetadata() -> ComponentProvidingMetadata<Self>
+    static var requirements: Set<AnyKey> { get }
 }
 
 extension Component {
     @inlinable
-    public func get<I>(_ key: some Key<I>) -> I {
-        return container.get(key)
+    public func get<I>(_ key: Key<I>) -> I {
+        if let c = Components.current {
+            return container.get(key, with: c)
+        }
+        let components = parents + CollectionOfOne<any Component>(self)
+        return Components.dollarCurrent.withValue(components) {
+            return container.get(key, with: components)
+        }
+    }
+
+    public mutating func initContainer(parent: (any DI.Component)?) {
+        if let parent {
+            assertRequirements(Self.requirements, container: parent.container)
+            container = parent.container
+            parents = parent.parents + CollectionOfOne<any Component>(parent)
+        }
+        container.combine(metadata: Self.buildMetadata())
+        for i in parents.indices {
+            parents[i].container = container
+        }
     }
 }
+
+@usableFromInline enum Components {
+    @TaskLocal
+    @usableFromInline static var current: [any Component]? = nil
+    @usableFromInline static var dollarCurrent: TaskLocal<[any Component]?> {
+        $current
+    }
+}
+

--- a/Sources/DI/ComponentProtocol.swift
+++ b/Sources/DI/ComponentProtocol.swift
@@ -17,11 +17,6 @@ extension Component {
         }
     }
 
-    @inlinable
-    public func _get<I>(_ key: Key<I>, with components: [any Component]) -> I {
-        return container.get(key, with: components)
-    }
-
     public mutating func initContainer(parent: (any DI.Component)?) {
         if let parent {
             assertRequirements(Self.requirements, container: parent.container)

--- a/Sources/DI/ComponentProtocol.swift
+++ b/Sources/DI/ComponentProtocol.swift
@@ -8,13 +8,8 @@ public protocol Component: Sendable {
 extension Component {
     @inlinable
     public func get<I>(_ key: Key<I>) -> I {
-        if let c = Components.current {
-            return container.get(key, with: c)
-        }
         let components = parents + CollectionOfOne<any Component>(self)
-        return Components.dollarCurrent.withValue(components) {
-            return container.get(key, with: components)
-        }
+        return container.get(key, with: components)
     }
 
     public mutating func initContainer(parent: (any DI.Component)?) {
@@ -29,12 +24,3 @@ extension Component {
         }
     }
 }
-
-@usableFromInline enum Components {
-    @TaskLocal
-    @usableFromInline static var current: [any Component]? = nil
-    @usableFromInline static var dollarCurrent: TaskLocal<[any Component]?> {
-        $current
-    }
-}
-

--- a/Sources/DI/Container.swift
+++ b/Sources/DI/Container.swift
@@ -15,7 +15,7 @@ public struct ComponentProvidingMetadata<C>: Sendable {
     @inlinable
     public func setter<I>(
         for key: Key<I>
-    ) -> (inout Self, @escaping @Sendable (C) -> I) -> () {
+    ) -> (inout Self, @escaping @Sendable (C, [any Component]) -> I) -> () {
         return { `self`, provide in
             self.table[key] = FunctionDescriptor(ref: provide)
         }
@@ -27,11 +27,11 @@ public protocol WitnessTableElement: Sendable {
 }
 
 @usableFromInline struct FunctionDescriptor<C, I>: WitnessTableElement {
-    @usableFromInline init(ref: @escaping @Sendable (C) -> I) {
+    @usableFromInline init(ref: @escaping @Sendable (C, [any Component]) -> I) {
         self.ref = ref
     }
     @usableFromInline typealias ValueType = C
-    @usableFromInline var ref: @Sendable (C) -> I
+    @usableFromInline var ref: @Sendable (C, [any Component]) -> I
 }
 
 public struct Container: Sendable {
@@ -69,7 +69,7 @@ public struct Container: Sendable {
         func openAndRun<E: WitnessTableElement>(_ element: E) -> Instance {
             func applyIfMatched<C: Component>(_ component: C, element: E) -> Instance? {
                 if C.self == E.ValueType.self {
-                    return (element as! FunctionDescriptor<C, Instance>).ref(component)
+                    return (element as! FunctionDescriptor<C, Instance>).ref(component, components)
                 }
                 return nil
             }

--- a/Sources/DI/Container.swift
+++ b/Sources/DI/Container.swift
@@ -15,7 +15,7 @@ public struct ComponentProvidingMetadata<C>: Sendable {
     @inlinable
     public func setter<I>(
         for key: Key<I>
-    ) -> (inout Self, @escaping @Sendable (C, [any Component]) -> I) -> () {
+    ) -> (inout Self, @escaping @Sendable (C) -> I) -> () {
         return { `self`, provide in
             self.table[key] = FunctionDescriptor(ref: provide)
         }
@@ -27,11 +27,11 @@ public protocol WitnessTableElement: Sendable {
 }
 
 @usableFromInline struct FunctionDescriptor<C, I>: WitnessTableElement {
-    @usableFromInline init(ref: @escaping @Sendable (C, [any Component]) -> I) {
+    @usableFromInline init(ref: @escaping @Sendable (C) -> I) {
         self.ref = ref
     }
     @usableFromInline typealias ValueType = C
-    @usableFromInline var ref: @Sendable (C, [any Component]) -> I
+    @usableFromInline var ref: @Sendable (C) -> I
 }
 
 public struct Container: Sendable {
@@ -69,7 +69,7 @@ public struct Container: Sendable {
         func openAndRun<E: WitnessTableElement>(_ element: E) -> Instance {
             func applyIfMatched<C: Component>(_ component: C, element: E) -> Instance? {
                 if C.self == E.ValueType.self {
-                    return (element as! FunctionDescriptor<C, Instance>).ref(component, components)
+                    return (element as! FunctionDescriptor<C, Instance>).ref(component)
                 }
                 return nil
             }

--- a/Sources/DI/Container.swift
+++ b/Sources/DI/Container.swift
@@ -46,7 +46,6 @@ public struct Container: Sendable {
         return combinedMetadata.keys
     }
 
-    @inlinable
     public mutating func combine(metadata: ComponentProvidingMetadata<some Component>) {
         for (key, function) in metadata.table {
             combinedMetadata[key] = function
@@ -54,7 +53,7 @@ public struct Container: Sendable {
     }
 
     @inlinable
-    public func get<Instance>(
+    internal func get<Instance>(
         _ key: Key<Instance>,
         with components: [any Component]
     ) -> Instance {

--- a/Sources/DI/Container.swift
+++ b/Sources/DI/Container.swift
@@ -46,6 +46,7 @@ public struct Container: Sendable {
         return combinedMetadata.keys
     }
 
+    @inlinable
     public mutating func combine(metadata: ComponentProvidingMetadata<some Component>) {
         for (key, function) in metadata.table {
             combinedMetadata[key] = function
@@ -53,7 +54,7 @@ public struct Container: Sendable {
     }
 
     @inlinable
-    internal func get<Instance>(
+    public func get<Instance>(
         _ key: Key<Instance>,
         with components: [any Component]
     ) -> Instance {

--- a/Sources/DI/Macros.swift
+++ b/Sources/DI/Macros.swift
@@ -3,7 +3,8 @@
     names:
         named(requirements),
     named(container),
-    named(initContainer),
+    named(parents),
+    named(buildMetadata),
     named(init(parent:)),
     named(init())
 )

--- a/Sources/DIMacros/Component/ComponentMacro.swift
+++ b/Sources/DIMacros/Component/ComponentMacro.swift
@@ -97,11 +97,6 @@ public struct ComponentMacro: MemberMacro, ExtensionMacro {
             providingKeys: Set(providings.map(\.key)),
             in: context
         ))
-//        result.append(buildInitContainer(
-//            requiredKeys: requiredKeysSorted,
-//            providingKeys: Set(providings.map(\.key)),
-//            in: context
-//        ))
         return result.map { DeclSyntax($0) }
     }
 
@@ -160,30 +155,11 @@ private func buildBuildMetadata(
     return try! FunctionDeclSyntax("\(modifiers)static func buildMetadata() -> ComponentProvidingMetadata<Self>") {
         "var metadata = ComponentProvidingMetadata<Self>()"
         for key in providingKeys.sorted() {
-//            "metadata.table[\(raw: key)] = FunctionDescriptor { (c: Self) in c.__provide_\(raw: funcNameSafe(key))() }"
             let setterName = context.makeUniqueName("set")
             "let \(setterName) = metadata.setter(for: \(raw: key))"
             "\(setterName)(&metadata, __provide_\(raw: funcNameSafe(key)))"
         }
         "return metadata"
-    }
-}
-
-private func buildInitContainer(
-    requiredKeys: [ExtractedKey],
-    providingKeys: Set<ExtractedKey>,
-    in context: some MacroExpansionContext
-) -> FunctionDeclSyntax {
-    return try! FunctionDeclSyntax("private mutating func initContainer(parent: some DI.Component)") {
-        if !requiredKeys.isEmpty {
-            "assertRequirements(Self.requirements, container: parent.container)"
-        }
-        "container = parent.container"
-        for key in providingKeys.sorted() {
-            let setterName = context.makeUniqueName("set")
-            "let \(setterName) = container.setter(for: \(raw: key))"
-            "\(setterName)(&container, __provide_\(raw: funcNameSafe(key)))"
-        }
     }
 }
 

--- a/Sources/DIMacros/Component/ComponentMacro.swift
+++ b/Sources/DIMacros/Component/ComponentMacro.swift
@@ -153,13 +153,17 @@ private func buildBuildMetadata(
     in context: some MacroExpansionContext
 ) -> FunctionDeclSyntax {
     return try! FunctionDeclSyntax("\(modifiers)static func buildMetadata() -> ComponentProvidingMetadata<Self>") {
-        "var metadata = ComponentProvidingMetadata<Self>()"
-        for key in providingKeys.sorted() {
-            let setterName = context.makeUniqueName("set")
-            "let \(setterName) = metadata.setter(for: \(raw: key))"
-            "\(setterName)(&metadata, __provide_\(raw: funcNameSafe(key)))"
+        if providingKeys.isEmpty {
+            "return ComponentProvidingMetadata<Self>()"
+        } else {
+            "var metadata = ComponentProvidingMetadata<Self>()"
+            for key in providingKeys.sorted() {
+                let setterName = context.makeUniqueName("set")
+                "let \(setterName) = metadata.setter(for: \(raw: key))"
+                "\(setterName)(&metadata, __provide_\(raw: funcNameSafe(key)))"
+            }
+            "return metadata"
         }
-        "return metadata"
     }
 }
 

--- a/Sources/DIMacros/Provides/ProvidesMacro.swift
+++ b/Sources/DIMacros/Provides/ProvidesMacro.swift
@@ -40,13 +40,12 @@ public struct ProvidesMacro: PeerMacro {
 
         let instanceDecl: DeclSyntax
         if let getterBlock {
-            // TODO: getterブロック内で`self.get`と呼び出されていた場合にも対応したい
             instanceDecl = """
             func `get`<I>(_ key: Key<I>) -> I {
                 self.container.get(key, with: components)
             }
             var instance: \(returnType.trimmed) {
-                \(getterBlock)
+                \(SelfGetRewriter().visit(getterBlock))
             }
             """
         } else {
@@ -76,5 +75,16 @@ extension AccessorBlockSyntax.Accessors {
                 decl.accessorSpecifier == .keyword(.get)
             }?.body?.statements
         }
+    }
+}
+
+private class SelfGetRewriter: SyntaxRewriter {
+    override func visit(_ node: FunctionCallExprSyntax) -> ExprSyntax {
+        if node.calledExpression.description == "self.get" {
+            var node = node
+            node.calledExpression = "get"
+            return ExprSyntax(node)
+        }
+        return super.visit(node)
     }
 }

--- a/Sources/DIMacros/Provides/ProvidesMacro.swift
+++ b/Sources/DIMacros/Provides/ProvidesMacro.swift
@@ -29,19 +29,6 @@ public struct ProvidesMacro: PeerMacro {
                   let type = binding.typeAnnotation?.type else {
                 throw MessageError("Expected a type annotation.")
             }
-//            if varDecl.bindingSpecifier.tokenKind == .keyword(.var) {
-//                if binding.accessorBlock == nil {
-//                    context.diagnose(.init(
-//                        node: declaration,
-//                        message: ProvidesMacroDiagnostic.plainVar,
-//                        fixIt: .replace(
-//                            message: ProvidesMacroDiagnostic.plainVar,
-//                            oldNode: varDecl.bindingSpecifier,
-//                            newNode: TokenSyntax(.keyword(.let), presence: .present)
-//                        )
-//                    ))
-//                }
-//            }
             returnType = type
             callExpr = "\(binding.pattern)"
         } else {

--- a/Sources/DIMacros/Provides/ProvidesMacro.swift
+++ b/Sources/DIMacros/Provides/ProvidesMacro.swift
@@ -38,30 +38,30 @@ public struct ProvidesMacro: PeerMacro {
             throw MessageError("@Provides should be added to the 'func' or 'var' or 'let'.")
         }
 
-        let instanceDecl: DeclSyntax
-        if let getterBlock {
-            instanceDecl = """
-            func `get`<I>(_ key: Key<I>) -> I {
-                self.container.get(key, with: components)
+        let f = try FunctionDeclSyntax("@Sendable private static func __provide_\(raw: funcNameSafe(keyIdentifier))(`self`: Self, components: [any Component]) -> \(returnType.trimmed)") {
+            if let getterBlock {
+                """
+                func `get`<I>(_ key: Key<I>) -> I {
+                    self.container.get(key, with: components)
+                }
+                """
+                """
+                let instance = { () -> \(returnType.trimmed) in
+                    \(SelfGetRewriter().visit(getterBlock).trimmed)
+                }()
+                """
+            } else {
+                "let instance = self.\(callExpr)"
             }
-            let instance = {
-                \(SelfGetRewriter().visit(getterBlock).trimmed)
-            }()
             """
-        } else {
-            instanceDecl = "let instance = self.\(callExpr)"
-        }
-
-        return ["""
-        @Sendable private static func __provide_\(raw: funcNameSafe(keyIdentifier))(`self`: Self, components: [any Component]) -> \(returnType.trimmed) {
-            \(instanceDecl)
             assert({
                 let check = DI.VariantChecker(\(raw: keyIdentifier))
                 return check(instance)
             }())
-            return instance
+            """
+            "return instance"
         }
-        """]
+        return [DeclSyntax(f)]
     }
 }
 

--- a/Sources/DIMacros/Provides/ProvidesMacro.swift
+++ b/Sources/DIMacros/Provides/ProvidesMacro.swift
@@ -43,7 +43,7 @@ public struct ProvidesMacro: PeerMacro {
             // TODO: getterブロック内で`self.get`と呼び出されていた場合にも対応したい
             instanceDecl = """
             func `get`<I>(_ key: Key<I>) -> I {
-                self.container.get(key, with: components)
+                self._get(key, with: components)
             }
             var instance: \(returnType.trimmed) {
                 \(getterBlock)

--- a/Sources/DIMacros/Provides/ProvidesMacro.swift
+++ b/Sources/DIMacros/Provides/ProvidesMacro.swift
@@ -43,7 +43,7 @@ public struct ProvidesMacro: PeerMacro {
             // TODO: getterブロック内で`self.get`と呼び出されていた場合にも対応したい
             instanceDecl = """
             func `get`<I>(_ key: Key<I>) -> I {
-                self._get(key, with: components)
+                self.container.get(key, with: components)
             }
             var instance: \(returnType.trimmed) {
                 \(getterBlock)

--- a/Sources/DIMacros/Provides/ProvidesMacro.swift
+++ b/Sources/DIMacros/Provides/ProvidesMacro.swift
@@ -15,7 +15,6 @@ public struct ProvidesMacro: PeerMacro {
 
         let returnType: TypeSyntax
         let callExpr: TokenSyntax
-        let getterBlock: CodeBlockItemListSyntax?
         if let functionDecl = declaration.as(FunctionDeclSyntax.self) {
             guard let type = functionDecl.signature.returnClause?.type else {
                 throw MessageError("Expected a return type.")
@@ -25,7 +24,6 @@ public struct ProvidesMacro: PeerMacro {
             }
             returnType = type
             callExpr = "\(functionDecl.name.trimmed)()"
-            getterBlock = functionDecl.body?.statements
         } else if let varDecl = declaration.as(VariableDeclSyntax.self) {
             guard let binding = varDecl.bindings.first,
                   let type = binding.typeAnnotation?.type else {
@@ -33,29 +31,13 @@ public struct ProvidesMacro: PeerMacro {
             }
             returnType = type
             callExpr = "\(binding.pattern)"
-            getterBlock = binding.accessorBlock?.accessors.getter
         } else {
             throw MessageError("@Provides should be added to the 'func' or 'var' or 'let'.")
         }
 
-        let instanceDecl: DeclSyntax
-        if let getterBlock {
-            // TODO: getterブロック内で`self.get`と呼び出されていた場合にも対応したい
-            instanceDecl = """
-            func `get`<I>(_ key: Key<I>) -> I {
-                self._get(key, with: components)
-            }
-            var instance: \(returnType.trimmed) {
-                \(getterBlock)
-            }
-            """
-        } else {
-            instanceDecl = "let instance = self.\(callExpr)"
-        }
-
         return ["""
-        @Sendable private static func __provide_\(raw: funcNameSafe(keyIdentifier))(`self`: Self, components: [any Component]) -> \(returnType.trimmed) {
-            \(instanceDecl)
+        @Sendable private static func __provide_\(raw: funcNameSafe(keyIdentifier))(`self`: Self) -> \(returnType.trimmed) {
+            let instance = self.\(callExpr)
             assert({
                 let check = DI.VariantChecker(\(raw: keyIdentifier))
                 return check(instance)
@@ -63,18 +45,5 @@ public struct ProvidesMacro: PeerMacro {
             return instance
         }
         """]
-    }
-}
-
-extension AccessorBlockSyntax.Accessors {
-    var `getter`: CodeBlockItemListSyntax? {
-        switch self {
-        case .getter(let syntax):
-            return syntax
-        case .accessors(let list):
-            return list.first { decl in
-                decl.accessorSpecifier == .keyword(.get)
-            }?.body?.statements
-        }
     }
 }

--- a/Sources/DIMacros/Provides/ProvidesMacro.swift
+++ b/Sources/DIMacros/Provides/ProvidesMacro.swift
@@ -29,19 +29,19 @@ public struct ProvidesMacro: PeerMacro {
                   let type = binding.typeAnnotation?.type else {
                 throw MessageError("Expected a type annotation.")
             }
-            if varDecl.bindingSpecifier.tokenKind == .keyword(.var) {
-                if binding.accessorBlock == nil {
-                    context.diagnose(.init(
-                        node: declaration,
-                        message: ProvidesMacroDiagnostic.plainVar,
-                        fixIt: .replace(
-                            message: ProvidesMacroDiagnostic.plainVar,
-                            oldNode: varDecl.bindingSpecifier,
-                            newNode: TokenSyntax(.keyword(.let), presence: .present)
-                        )
-                    ))
-                }
-            }
+//            if varDecl.bindingSpecifier.tokenKind == .keyword(.var) {
+//                if binding.accessorBlock == nil {
+//                    context.diagnose(.init(
+//                        node: declaration,
+//                        message: ProvidesMacroDiagnostic.plainVar,
+//                        fixIt: .replace(
+//                            message: ProvidesMacroDiagnostic.plainVar,
+//                            oldNode: varDecl.bindingSpecifier,
+//                            newNode: TokenSyntax(.keyword(.let), presence: .present)
+//                        )
+//                    ))
+//                }
+//            }
             returnType = type
             callExpr = "\(binding.pattern)"
         } else {
@@ -49,10 +49,8 @@ public struct ProvidesMacro: PeerMacro {
         }
 
         return ["""
-        @Sendable private func __provide_\(raw: funcNameSafe(keyIdentifier))(container: DI.Container) -> \(returnType.trimmed) {
-            var copy = self
-            copy.container = container
-            let instance = copy.\(callExpr)
+        @Sendable private static func __provide_\(raw: funcNameSafe(keyIdentifier))(`self`: Self) -> \(returnType.trimmed) {
+            let instance = self.\(callExpr)
             assert({
                 let check = DI.VariantChecker(\(raw: keyIdentifier))
                 return check(instance)

--- a/Sources/DIMacros/Provides/ProvidesMacro.swift
+++ b/Sources/DIMacros/Provides/ProvidesMacro.swift
@@ -40,12 +40,13 @@ public struct ProvidesMacro: PeerMacro {
 
         let instanceDecl: DeclSyntax
         if let getterBlock {
+            // TODO: getterブロック内で`self.get`と呼び出されていた場合にも対応したい
             instanceDecl = """
             func `get`<I>(_ key: Key<I>) -> I {
                 self.container.get(key, with: components)
             }
             var instance: \(returnType.trimmed) {
-                \(SelfGetRewriter().visit(getterBlock))
+                \(getterBlock)
             }
             """
         } else {
@@ -75,16 +76,5 @@ extension AccessorBlockSyntax.Accessors {
                 decl.accessorSpecifier == .keyword(.get)
             }?.body?.statements
         }
-    }
-}
-
-private class SelfGetRewriter: SyntaxRewriter {
-    override func visit(_ node: FunctionCallExprSyntax) -> ExprSyntax {
-        if node.calledExpression.description == "self.get" {
-            var node = node
-            node.calledExpression = "get"
-            return ExprSyntax(node)
-        }
-        return super.visit(node)
     }
 }

--- a/Sources/DIMacros/Provides/ProvidesMacroDiagnostic.swift
+++ b/Sources/DIMacros/Provides/ProvidesMacroDiagnostic.swift
@@ -1,15 +1,11 @@
 import SwiftDiagnostics
 
 enum ProvidesMacroDiagnostic: DiagnosticMessage, FixItMessage {
-    case plainVar
-
     var severity: DiagnosticSeverity { .warning }
 
     @_implements(DiagnosticMessage, message)
     var diagnosticMessage: String {
         switch self {
-        case .plainVar:
-            return "Attaching @Provides to a stored 'var' may cause unexpected behavior, because modifying it after the initContainer(parent:) call does not affect the container."
         }
     }
 
@@ -20,8 +16,6 @@ enum ProvidesMacroDiagnostic: DiagnosticMessage, FixItMessage {
     @_implements(FixItMessage, message)
     var fixItMessage: String {
         switch self {
-        case .plainVar:
-            return "change 'var' to 'let'"
         }
     }
 

--- a/Sources/DIMacros/extractKey.swift
+++ b/Sources/DIMacros/extractKey.swift
@@ -51,7 +51,7 @@ private class GetCallVisitor: SyntaxVisitor {
     var keys = [ExprSyntax]()
 
     override func visit(_ node: FunctionCallExprSyntax) -> SyntaxVisitorContinueKind {
-        if ["get", "container.get", "self.get", "self.container.get"].contains(node.calledExpression.description) {
+        if ["get", "self.get"].contains(node.calledExpression.description) {
             if let firstArg = node.arguments.first?.expression {
                 keys.append(firstArg)
             }

--- a/Tests/DIMacrosTests/ComponentMacroTests.swift
+++ b/Tests/DIMacrosTests/ComponentMacroTests.swift
@@ -30,8 +30,7 @@ struct EmptyComponent {
     }
 
     static func buildMetadata() -> ComponentProvidingMetadata<Self> {
-        var metadata = ComponentProvidingMetadata<Self>()
-        return metadata
+        return ComponentProvidingMetadata<Self>()
     }
 }
 
@@ -62,8 +61,7 @@ struct RootComponent {
     }
 
     static func buildMetadata() -> ComponentProvidingMetadata<Self> {
-        var metadata = ComponentProvidingMetadata<Self>()
-        return metadata
+        return ComponentProvidingMetadata<Self>()
     }
 }
 
@@ -100,8 +98,7 @@ struct RootComponent {
     }
 
     static func buildMetadata() -> ComponentProvidingMetadata<Self> {
-        var metadata = ComponentProvidingMetadata<Self>()
-        return metadata
+        return ComponentProvidingMetadata<Self>()
     }
 }
 
@@ -210,8 +207,7 @@ struct MyComponent {
     }
 
     static func buildMetadata() -> ComponentProvidingMetadata<Self> {
-        var metadata = ComponentProvidingMetadata<Self>()
-        return metadata
+        return ComponentProvidingMetadata<Self>()
     }
 }
 
@@ -243,8 +239,7 @@ public struct RootComponent {
     }
 
     public static func buildMetadata() -> ComponentProvidingMetadata<Self> {
-        var metadata = ComponentProvidingMetadata<Self>()
-        return metadata
+        return ComponentProvidingMetadata<Self>()
     }
 }
 
@@ -274,8 +269,7 @@ public struct MyComponent {
     }
 
     public static func buildMetadata() -> ComponentProvidingMetadata<Self> {
-        var metadata = ComponentProvidingMetadata<Self>()
-        return metadata
+        return ComponentProvidingMetadata<Self>()
     }
 }
 
@@ -308,8 +302,7 @@ struct MyComponent {
     var parents = [any DI.Component] ()
 
     static func buildMetadata() -> ComponentProvidingMetadata<Self> {
-        var metadata = ComponentProvidingMetadata<Self>()
-        return metadata
+        return ComponentProvidingMetadata<Self>()
     }
 }
 

--- a/Tests/DIMacrosTests/ComponentMacroTests.swift
+++ b/Tests/DIMacrosTests/ComponentMacroTests.swift
@@ -134,17 +134,12 @@ struct AnonymousComponent {
         URL(string: "https://foo.example.com/\(get(.apiVersion))/")!
     }
 
-    @Sendable private static func __provide_baseURLKey(`self`: Self, components: [any Component]) -> URL {
-        func `get`<I>(_ key: Key<I>) -> I {
-            self.container.get(key, with: components)
-        }
-        let instance = { () -> URL in
-            URL(string: "https://foo.example.com/\(get(.apiVersion))/")!
-        }()
+    @Sendable private static func __provide_baseURLKey(`self`: Self) -> URL {
+        let instance = self.baseURL()
         assert({
             let check = DI.VariantChecker(baseURLKey)
             return check(instance)
-            }())
+        }())
         return instance
     }
 

--- a/Tests/DIMacrosTests/ComponentMacroTests.swift
+++ b/Tests/DIMacrosTests/ComponentMacroTests.swift
@@ -17,14 +17,21 @@ struct EmptyComponent {
 """, expandedSource: """
 struct EmptyComponent {
 
+    static var requirements: Set<DI.AnyKey> {
+        []
+    }
+
     var container = DI.Container()
+
+    var parents = [any DI.Component] ()
 
     init(parent: some DI.Component) {
         initContainer(parent: parent)
     }
 
-    private mutating func initContainer(parent: some DI.Component) {
-        container = parent.container
+    static func buildMetadata() -> ComponentProvidingMetadata<Self> {
+        var metadata = ComponentProvidingMetadata<Self>()
+        return metadata
     }
 }
 
@@ -42,14 +49,21 @@ struct RootComponent {
 """, expandedSource: """
 struct RootComponent {
 
-    var container = DI.Container()
-
-    init() {
-        initContainer(parent: self)
+    static var requirements: Set<DI.AnyKey> {
+        []
     }
 
-    private mutating func initContainer(parent: some DI.Component) {
-        container = parent.container
+    var container = DI.Container()
+
+    var parents = [any DI.Component] ()
+
+    init() {
+        initContainer(parent: nil)
+    }
+
+    static func buildMetadata() -> ComponentProvidingMetadata<Self> {
+        var metadata = ComponentProvidingMetadata<Self>()
+        return metadata
     }
 }
 
@@ -79,13 +93,15 @@ struct RootComponent {
 
     var container = DI.Container()
 
+    var parents = [any DI.Component] ()
+
     init() {
-        initContainer(parent: self)
+        initContainer(parent: nil)
     }
 
-    private mutating func initContainer(parent: some DI.Component) {
-        assertRequirements(Self.requirements, container: parent.container)
-        container = parent.container
+    static func buildMetadata() -> ComponentProvidingMetadata<Self> {
+        var metadata = ComponentProvidingMetadata<Self>()
+        return metadata
     }
 }
 
@@ -118,10 +134,8 @@ struct AnonymousComponent {
         URL(string: "https://foo.example.com/\(get(.apiVersion))/")!
     }
 
-    @Sendable private func __provide_baseURLKey(container: DI.Container) -> URL {
-        var copy = self
-        copy.container = container
-        let instance = copy.baseURL()
+    @Sendable private static func __provide_baseURLKey(`self`: Self) -> URL {
+        let instance = self.baseURL()
         assert({
             let check = DI.VariantChecker(baseURLKey)
             return check(instance)
@@ -141,15 +155,17 @@ struct AnonymousComponent {
 
     var container = DI.Container()
 
+    var parents = [any DI.Component] ()
+
     init(parent: some DI.Component) {
         initContainer(parent: parent)
     }
 
-    private mutating func initContainer(parent: some DI.Component) {
-        assertRequirements(Self.requirements, container: parent.container)
-        container = parent.container
-        let __macro_local_3setfMu_ = container.setter(for: baseURLKey)
-        __macro_local_3setfMu_(&container, __provide_baseURLKey)
+    static func buildMetadata() -> ComponentProvidingMetadata<Self> {
+        var metadata = ComponentProvidingMetadata<Self>()
+        let __macro_local_3setfMu_ = metadata.setter(for: baseURLKey)
+        __macro_local_3setfMu_(&metadata, __provide_baseURLKey)
+        return metadata
     }
 }
 
@@ -167,9 +183,7 @@ struct MyComponent {
     var manager: any Manager {
         AppManager(
             foo: get(.foo),
-            bar: self.get(.bar),
-            baz: container.get(.baz),
-            qux: self.container.get(.qux)
+            bar: self.get(.bar)
         )
     }
 }
@@ -179,25 +193,25 @@ struct MyComponent {
     var manager: any Manager {
         AppManager(
             foo: get(.foo),
-            bar: self.get(.bar),
-            baz: container.get(.baz),
-            qux: self.container.get(.qux)
+            bar: self.get(.bar)
         )
     }
 
     static var requirements: Set<DI.AnyKey> {
-        [.bar, .baz, .foo, .qux]
+        [.bar, .foo]
     }
 
     var container = DI.Container()
+
+    var parents = [any DI.Component] ()
 
     init(parent: some DI.Component) {
         initContainer(parent: parent)
     }
 
-    private mutating func initContainer(parent: some DI.Component) {
-        assertRequirements(Self.requirements, container: parent.container)
-        container = parent.container
+    static func buildMetadata() -> ComponentProvidingMetadata<Self> {
+        var metadata = ComponentProvidingMetadata<Self>()
+        return metadata
     }
 }
 
@@ -216,14 +230,21 @@ public struct RootComponent {
 """#, expandedSource: #"""
 public struct RootComponent {
 
-    public var container = DI.Container()
-
-    public init() {
-        initContainer(parent: self)
+    static var requirements: Set<DI.AnyKey> {
+        []
     }
 
-    private mutating func initContainer(parent: some DI.Component) {
-        container = parent.container
+    public var container = DI.Container()
+
+    public var parents = [any DI.Component] ()
+
+    public init() {
+        initContainer(parent: nil)
+    }
+
+    public static func buildMetadata() -> ComponentProvidingMetadata<Self> {
+        var metadata = ComponentProvidingMetadata<Self>()
+        return metadata
     }
 }
 
@@ -240,14 +261,21 @@ public struct MyComponent {
 """#, expandedSource: #"""
 public struct MyComponent {
 
+    static var requirements: Set<DI.AnyKey> {
+        []
+    }
+
     public var container = DI.Container()
+
+    public var parents = [any DI.Component] ()
 
     public init(parent: some DI.Component) {
         initContainer(parent: parent)
     }
 
-    private mutating func initContainer(parent: some DI.Component) {
-        container = parent.container
+    public static func buildMetadata() -> ComponentProvidingMetadata<Self> {
+        var metadata = ComponentProvidingMetadata<Self>()
+        return metadata
     }
 }
 
@@ -271,10 +299,17 @@ struct MyComponent {
     init(parent: some DI.Component) {
     }
 
+    static var requirements: Set<DI.AnyKey> {
+        []
+    }
+
     var container = DI.Container()
 
-    private mutating func initContainer(parent: some DI.Component) {
-        container = parent.container
+    var parents = [any DI.Component] ()
+
+    static func buildMetadata() -> ComponentProvidingMetadata<Self> {
+        var metadata = ComponentProvidingMetadata<Self>()
+        return metadata
     }
 }
 
@@ -338,18 +373,25 @@ struct MyComponent {
         )
     }
 
+    static var requirements: Set<DI.AnyKey> {
+        []
+    }
+
     var container = DI.Container()
+
+    var parents = [any DI.Component] ()
 
     init(parent: some DI.Component) {
         initContainer(parent: parent)
     }
 
-    private mutating func initContainer(parent: some DI.Component) {
-        container = parent.container
-        let __macro_local_3setfMu_ = container.setter(for: .bar)
-        __macro_local_3setfMu_(&container, __provide__bar)
-        let __macro_local_3setfMu0_ = container.setter(for: .foo)
-        __macro_local_3setfMu0_(&container, __provide__foo)
+    static func buildMetadata() -> ComponentProvidingMetadata<Self> {
+        var metadata = ComponentProvidingMetadata<Self>()
+        let __macro_local_3setfMu_ = metadata.setter(for: .bar)
+        __macro_local_3setfMu_(&metadata, __provide__bar)
+        let __macro_local_3setfMu0_ = metadata.setter(for: .foo)
+        __macro_local_3setfMu0_(&metadata, __provide__foo)
+        return metadata
     }
 }
 

--- a/Tests/DIMacrosTests/ComponentMacroTests.swift
+++ b/Tests/DIMacrosTests/ComponentMacroTests.swift
@@ -134,12 +134,17 @@ struct AnonymousComponent {
         URL(string: "https://foo.example.com/\(get(.apiVersion))/")!
     }
 
-    @Sendable private static func __provide_baseURLKey(`self`: Self) -> URL {
-        let instance = self.baseURL()
+    @Sendable private static func __provide_baseURLKey(`self`: Self, components: [any Component]) -> URL {
+        func `get`<I>(_ key: Key<I>) -> I {
+            self.container.get(key, with: components)
+        }
+        let instance = { () -> URL in
+            URL(string: "https://foo.example.com/\(get(.apiVersion))/")!
+        }()
         assert({
             let check = DI.VariantChecker(baseURLKey)
             return check(instance)
-        }())
+            }())
         return instance
     }
 

--- a/Tests/DIMacrosTests/ProvidesMacroTests.swift
+++ b/Tests/DIMacrosTests/ProvidesMacroTests.swift
@@ -22,17 +22,12 @@ struct RootComponent {
         APIClient()
     }
 
-    @Sendable private static func __provide__apiClient(`self`: Self, components: [any Component]) -> APIClient {
-        func `get`<I>(_ key: Key<I>) -> I {
-            self.container.get(key, with: components)
-        }
-        let instance = { () -> APIClient in
-            APIClient()
-        }()
+    @Sendable private static func __provide__apiClient(`self`: Self) -> APIClient {
+        let instance = self.apiClient()
         assert({
             let check = DI.VariantChecker(.apiClient)
             return check(instance)
-            }())
+        }())
         return instance
     }
 }
@@ -65,7 +60,8 @@ struct RootComponent {
         )
     }
 
-    func testStoredVar() {
+    func testProperty() {
+        // stored var
         assertMacroExpansion(
 """
 struct RootComponent {
@@ -77,21 +73,20 @@ expandedSource: """
 struct RootComponent {
     var urlSession: URLSession
 
-    @Sendable private static func __provide__urlSession(`self`: Self, components: [any Component]) -> URLSession {
+    @Sendable private static func __provide__urlSession(`self`: Self) -> URLSession {
         let instance = self.urlSession
         assert({
             let check = DI.VariantChecker(.urlSession)
             return check(instance)
-            }())
+        }())
         return instance
     }
 }
 """,
 macros: macros
         )
-    }
 
-    func testComputedVar() {
+        // computed var
         assertMacroExpansion("""
 struct RootComponent {
     @Provides(.urlSession)
@@ -105,23 +100,17 @@ struct RootComponent {
         .shared
     }
 
-    @Sendable private static func __provide__urlSession(`self`: Self, components: [any Component]) -> URLSession {
-        func `get`<I>(_ key: Key<I>) -> I {
-            self.container.get(key, with: components)
-        }
-        let instance = { () -> URLSession in
-            .shared
-        }()
+    @Sendable private static func __provide__urlSession(`self`: Self) -> URLSession {
+        let instance = self.urlSession
         assert({
             let check = DI.VariantChecker(.urlSession)
             return check(instance)
-            }())
+        }())
         return instance
     }
 }
 """, macros: macros
         )
-    }
 
     func testComputedVarAccessors() {
         assertMacroExpansion("""
@@ -166,7 +155,6 @@ struct RootComponent {
     }
 
     func testStoredLet() {
-        // stored let
         assertMacroExpansion("""
 struct RootComponent {
     @Provides(.urlSession)
@@ -176,12 +164,12 @@ struct RootComponent {
 struct RootComponent {
     let urlSession: URLSession
 
-    @Sendable private static func __provide__urlSession(`self`: Self, components: [any Component]) -> URLSession {
+    @Sendable private static func __provide__urlSession(`self`: Self) -> URLSession {
         let instance = self.urlSession
         assert({
             let check = DI.VariantChecker(.urlSession)
             return check(instance)
-            }())
+        }())
         return instance
     }
 }

--- a/Tests/DIMacrosTests/ProvidesMacroTests.swift
+++ b/Tests/DIMacrosTests/ProvidesMacroTests.swift
@@ -123,6 +123,48 @@ struct RootComponent {
         )
     }
 
+    func testComputedVarAccessors() {
+        assertMacroExpansion("""
+struct RootComponent {
+    @Provides(.urlSession)
+    var urlSession: URLSession {
+        set {
+            fatalError()
+        }
+        get {
+            .shared
+        }
+    }
+}
+""", expandedSource: """
+struct RootComponent {
+    var urlSession: URLSession {
+        set {
+            fatalError()
+        }
+        get {
+            .shared
+        }
+    }
+
+    @Sendable private static func __provide__urlSession(`self`: Self, components: [any Component]) -> URLSession {
+        func `get`<I>(_ key: Key<I>) -> I {
+            self.container.get(key, with: components)
+        }
+        let instance = { () -> URLSession in
+            .shared
+        }()
+        assert({
+            let check = DI.VariantChecker(.urlSession)
+            return check(instance)
+            }())
+        return instance
+    }
+}
+""", macros: macros
+        )
+    }
+
     func testStoredLet() {
         // stored let
         assertMacroExpansion("""

--- a/Tests/DIMacrosTests/ProvidesMacroTests.swift
+++ b/Tests/DIMacrosTests/ProvidesMacroTests.swift
@@ -60,8 +60,7 @@ struct RootComponent {
         )
     }
 
-    func testProperty() {
-        // stored var
+    func testStoredVar() {
         assertMacroExpansion(
 """
 struct RootComponent {
@@ -85,8 +84,9 @@ struct RootComponent {
 """,
 macros: macros
         )
+    }
 
-        // computed var
+    func testComputedVar() {
         assertMacroExpansion("""
 struct RootComponent {
     @Provides(.urlSession)
@@ -111,6 +111,7 @@ struct RootComponent {
 }
 """, macros: macros
         )
+    }
 
     func testComputedVarAccessors() {
         assertMacroExpansion("""
@@ -136,17 +137,12 @@ struct RootComponent {
         }
     }
 
-    @Sendable private static func __provide__urlSession(`self`: Self, components: [any Component]) -> URLSession {
-        func `get`<I>(_ key: Key<I>) -> I {
-            self.container.get(key, with: components)
-        }
-        let instance = { () -> URLSession in
-            .shared
-        }()
+    @Sendable private static func __provide__urlSession(`self`: Self) -> URLSession {
+        let instance = self.urlSession
         assert({
             let check = DI.VariantChecker(.urlSession)
             return check(instance)
-            }())
+        }())
         return instance
     }
 }
@@ -192,8 +188,4 @@ struct RootComponent {
 ], macros: macros
         )
     }
-}
-
-struct S {
-    var foo: Int, bar: Int
 }

--- a/Tests/DIMacrosTests/ProvidesMacroTests.swift
+++ b/Tests/DIMacrosTests/ProvidesMacroTests.swift
@@ -22,10 +22,8 @@ struct RootComponent {
         APIClient()
     }
 
-    @Sendable private func __provide__apiClient(container: DI.Container) -> APIClient {
-        var copy = self
-        copy.container = container
-        let instance = copy.apiClient()
+    @Sendable private static func __provide__apiClient(`self`: Self) -> APIClient {
+        let instance = self.apiClient()
         assert({
             let check = DI.VariantChecker(.apiClient)
             return check(instance)
@@ -75,10 +73,8 @@ expandedSource: """
 struct RootComponent {
     var urlSession: URLSession
 
-    @Sendable private func __provide__urlSession(container: DI.Container) -> URLSession {
-        var copy = self
-        copy.container = container
-        let instance = copy.urlSession
+    @Sendable private static func __provide__urlSession(`self`: Self) -> URLSession {
+        let instance = self.urlSession
         assert({
             let check = DI.VariantChecker(.urlSession)
             return check(instance)
@@ -87,17 +83,6 @@ struct RootComponent {
     }
 }
 """,
-diagnostics: [
-    .init(
-        message: "Attaching @Provides to a stored 'var' may cause unexpected behavior, because modifying it after the initContainer(parent:) call does not affect the container.",
-        line: 2,
-        column: 5,
-        severity: .warning,
-        fixIts: [.init(
-            message: "change 'var' to 'let'"
-        )]
-    )
-],
 macros: macros
         )
 
@@ -115,10 +100,8 @@ struct RootComponent {
         .shared
     }
 
-    @Sendable private func __provide__urlSession(container: DI.Container) -> URLSession {
-        var copy = self
-        copy.container = container
-        let instance = copy.urlSession
+    @Sendable private static func __provide__urlSession(`self`: Self) -> URLSession {
+        let instance = self.urlSession
         assert({
             let check = DI.VariantChecker(.urlSession)
             return check(instance)
@@ -139,10 +122,8 @@ struct RootComponent {
 struct RootComponent {
     let urlSession: URLSession
 
-    @Sendable private func __provide__urlSession(container: DI.Container) -> URLSession {
-        var copy = self
-        copy.container = container
-        let instance = copy.urlSession
+    @Sendable private static func __provide__urlSession(`self`: Self) -> URLSession {
+        let instance = self.urlSession
         assert({
             let check = DI.VariantChecker(.urlSession)
             return check(instance)

--- a/Tests/DITests/ComponentTests.swift
+++ b/Tests/DITests/ComponentTests.swift
@@ -2,13 +2,13 @@ import DI
 import XCTest
 
 extension AnyKey {
-    static let name = Key<String>()
-    static let age = Key<Int>()
-    static let message = Key<String>()
+    fileprivate static let name = Key<String>()
+    fileprivate static let age = Key<Int>()
+    fileprivate static let message = Key<String>()
 }
 
 @Component(root: true)
-struct RootComponent: Sendable {
+fileprivate struct RootComponent: Sendable {
     @Provides(.name)
     var name: String {
         "RootComponent"
@@ -25,7 +25,7 @@ struct RootComponent: Sendable {
 }
 
 @Component
-struct ParentComponent: Sendable {
+fileprivate struct ParentComponent: Sendable {
     @Provides(.name)
     var name: String {
         "ParentComponent"
@@ -42,7 +42,7 @@ struct ParentComponent: Sendable {
 }
 
 @Component
-struct ChildComponent: Sendable {
+fileprivate struct ChildComponent: Sendable {
     @Provides(.name)
     var name: String = "ChildComponent"
 
@@ -52,7 +52,7 @@ struct ChildComponent: Sendable {
 }
 
 final class ComponentTests: XCTestCase {
-    func testInheritance() {
+    func testInheritanceAndOverrride() {
         let root = RootComponent()
         let parent = root.parentComponent
         XCTAssertEqual(parent.message, "I'm ParentComponent, age=42")

--- a/Tests/DITests/ComponentTests.swift
+++ b/Tests/DITests/ComponentTests.swift
@@ -5,9 +5,6 @@ extension AnyKey {
     fileprivate static let name = Key<String>()
     fileprivate static let age = Key<Int>()
     fileprivate static let message = Key<String>()
-    fileprivate static let getPatternA = Key<String>()
-    fileprivate static let getPatternB = Key<String>()
-    fileprivate static let getPatternC = Key<String>()
 }
 
 @Component(root: true)
@@ -39,26 +36,6 @@ fileprivate struct ParentComponent: Sendable {
         "I'm \(get(.name)), age=\(get(.age))"
     }
 
-    @Provides(.getPatternA)
-    var getPatternA: String {
-        self.get(.name) + get(.name)
-    }
-
-    @Provides(.getPatternB)
-    var getPatternB: String {
-        get {
-            "\(get(.name))\(self.get(.name))"
-        }
-    }
-
-    @Provides(.getPatternC)
-    func getPatternC() -> String {
-        return [
-            self.get(.name),
-            get(.name),
-        ].joined()
-    }
-
     var childComponent: ChildComponent {
         ChildComponent(parent: self)
     }
@@ -71,10 +48,6 @@ fileprivate struct ChildComponent: Sendable {
 
     func message() -> String {
         get(.message)
-    }
-
-    func getPatterns() -> (String, String, String) {
-        (get(.getPatternA), get(.getPatternB), get(.getPatternC))
     }
 }
 
@@ -93,14 +66,5 @@ final class ComponentTests: XCTestCase {
 
         child.name = "Foo"
         XCTAssertEqual(child.message(), "I'm Foo, age=42")
-    }
-
-    func testGetPatterns() {
-        var child = RootComponent().parentComponent.childComponent
-        child.name = "<>"
-        let (a, b, c) = child.getPatterns()
-        XCTAssertEqual(a, "<><>")
-        XCTAssertEqual(b, "<><>")
-        XCTAssertEqual(c, "<><>")
     }
 }

--- a/Tests/DITests/ComponentTests.swift
+++ b/Tests/DITests/ComponentTests.swift
@@ -1,0 +1,70 @@
+import DI
+import XCTest
+
+extension AnyKey {
+    static let name = Key<String>()
+    static let age = Key<Int>()
+    static let message = Key<String>()
+}
+
+@Component(root: true)
+struct RootComponent: Sendable {
+    @Provides(.name)
+    var name: String {
+        "RootComponent"
+    }
+
+    @Provides(.age)
+    func age() -> Int {
+        42
+    }
+
+    var parentComponent: ParentComponent {
+        ParentComponent(parent: self)
+    }
+}
+
+@Component
+struct ParentComponent: Sendable {
+    @Provides(.name)
+    var name: String {
+        "ParentComponent"
+    }
+
+    @Provides(.message)
+    var message: String {
+        "I'm \(get(.name)), age=\(get(.age))"
+    }
+
+    var childComponent: ChildComponent {
+        ChildComponent(parent: self)
+    }
+}
+
+@Component
+struct ChildComponent: Sendable {
+    @Provides(.name)
+    var name: String = "ChildComponent"
+
+    func message() -> String {
+        get(.message)
+    }
+}
+
+final class ComponentTests: XCTestCase {
+    func testInheritance() {
+        let root = RootComponent()
+        let parent = root.parentComponent
+        XCTAssertEqual(parent.message, "I'm ParentComponent, age=42")
+        let child = parent.childComponent
+        XCTAssertEqual(child.message(), "I'm ChildComponent, age=42")
+    }
+
+    func testMutateSelf() {
+        var child = RootComponent().parentComponent.childComponent
+        XCTAssertEqual(child.message(), "I'm ChildComponent, age=42")
+
+        child.name = "Foo"
+        XCTAssertEqual(child.message(), "I'm Foo, age=42")
+    }
+}

--- a/Tests/DITests/ComponentTests.swift
+++ b/Tests/DITests/ComponentTests.swift
@@ -5,6 +5,9 @@ extension AnyKey {
     fileprivate static let name = Key<String>()
     fileprivate static let age = Key<Int>()
     fileprivate static let message = Key<String>()
+    fileprivate static let getPatternA = Key<String>()
+    fileprivate static let getPatternB = Key<String>()
+    fileprivate static let getPatternC = Key<String>()
 }
 
 @Component(root: true)
@@ -36,6 +39,26 @@ fileprivate struct ParentComponent: Sendable {
         "I'm \(get(.name)), age=\(get(.age))"
     }
 
+    @Provides(.getPatternA)
+    var getPatternA: String {
+        self.get(.name) + get(.name)
+    }
+
+    @Provides(.getPatternB)
+    var getPatternB: String {
+        get {
+            "\(get(.name))\(self.get(.name))"
+        }
+    }
+
+    @Provides(.getPatternC)
+    func getPatternC() -> String {
+        return [
+            self.get(.name),
+            get(.name),
+        ].joined()
+    }
+
     var childComponent: ChildComponent {
         ChildComponent(parent: self)
     }
@@ -48,6 +71,10 @@ fileprivate struct ChildComponent: Sendable {
 
     func message() -> String {
         get(.message)
+    }
+
+    func getPatterns() -> (String, String, String) {
+        (get(.getPatternA), get(.getPatternB), get(.getPatternC))
     }
 }
 
@@ -66,5 +93,14 @@ final class ComponentTests: XCTestCase {
 
         child.name = "Foo"
         XCTAssertEqual(child.message(), "I'm Foo, age=42")
+    }
+
+    func testGetPatterns() {
+        var child = RootComponent().parentComponent.childComponent
+        child.name = "<>"
+        let (a, b, c) = child.getPatterns()
+        XCTAssertEqual(a, "<><>")
+        XCTAssertEqual(b, "<><>")
+        XCTAssertEqual(c, "<><>")
     }
 }

--- a/Tests/DITests/PerformanceTests.swift
+++ b/Tests/DITests/PerformanceTests.swift
@@ -1,0 +1,477 @@
+import DI
+import XCTest
+
+@inline(never)
+func blackhole(_: some Any) {}
+
+private let loop = 2000
+
+final class PerformanceTests: XCTestCase {
+    func testAA() {
+        let root = RootComponent()
+        print(#function, root.parentAComponent.childAComponent.take())
+        measure {
+            DispatchQueue.concurrentPerform(iterations: loop) { _ in
+                let component = root.parentAComponent.childAComponent
+                blackhole(component.take())
+            }
+        }
+    }
+
+    func testAB() {
+        let root = RootComponent()
+        print(#function, root.parentAComponent.childBComponent.take())
+        measure {
+            DispatchQueue.concurrentPerform(iterations: loop) { _ in
+                let component = root.parentAComponent.childBComponent
+                blackhole(component.take())
+            }
+        }
+    }
+
+    func testBA() {
+        let root = RootComponent()
+        print(#function, root.parentBComponent.childAComponent.take())
+        measure {
+            DispatchQueue.concurrentPerform(iterations: loop) { _ in
+                let component = root.parentBComponent.childAComponent
+                blackhole(component.take())
+            }
+        }
+    }
+
+    func testBB() {
+        let root = RootComponent()
+        print(#function, root.parentBComponent.childBComponent.take())
+        measure {
+            DispatchQueue.concurrentPerform(iterations: loop) { _ in
+                let component = root.parentBComponent.childBComponent
+                blackhole(component.take())
+            }
+        }
+    }
+
+    func testMixed() {
+        let root = RootComponent()
+        measure {
+            DispatchQueue.concurrentPerform(iterations: loop) { i in
+                let v = switch i % 4 {
+                case 0:
+                    root.parentAComponent.childAComponent.take()
+                case 1:
+                    root.parentAComponent.childBComponent.take()
+                case 2:
+                    root.parentBComponent.childAComponent.take()
+                default:
+                    root.parentBComponent.childBComponent.take()
+                }
+                blackhole(v)
+            }
+        }
+    }
+}
+
+extension AnyKey {
+    fileprivate static let dependency0 = Key<String>()
+    fileprivate static let dependency1 = Key<String>()
+    fileprivate static let dependency2 = Key<String>()
+    fileprivate static let dependency3 = Key<String>()
+    fileprivate static let dependency4 = Key<String>()
+    fileprivate static let dependency5 = Key<String>()
+    fileprivate static let dependency6 = Key<String>()
+    fileprivate static let dependency7 = Key<String>()
+    fileprivate static let dependency8 = Key<String>()
+    fileprivate static let dependency9 = Key<String>()
+    fileprivate static let dependency10 = Key<String>()
+    fileprivate static let dependency11 = Key<String>()
+    fileprivate static let dependency12 = Key<String>()
+    fileprivate static let dependency13 = Key<String>()
+    fileprivate static let dependency14 = Key<String>()
+    fileprivate static let dependency15 = Key<String>()
+    fileprivate static let dependency16 = Key<String>()
+    fileprivate static let dependency17 = Key<String>()
+    fileprivate static let dependency18 = Key<String>()
+    fileprivate static let dependency19 = Key<String>()
+    fileprivate static let dependency20 = Key<String>()
+    fileprivate static let dependency21 = Key<String>()
+    fileprivate static let dependency22 = Key<String>()
+    fileprivate static let dependency23 = Key<String>()
+    fileprivate static let dependency24 = Key<String>()
+    fileprivate static let dependency25 = Key<String>()
+    fileprivate static let dependency26 = Key<String>()
+    fileprivate static let dependency27 = Key<String>()
+    fileprivate static let dependency28 = Key<String>()
+    fileprivate static let dependency29 = Key<String>()
+    fileprivate static let dependency30 = Key<String>()
+    fileprivate static let dependency31 = Key<String>()
+    fileprivate static let dependency32 = Key<String>()
+    fileprivate static let dependency33 = Key<String>()
+    fileprivate static let dependency34 = Key<String>()
+    fileprivate static let dependency35 = Key<String>()
+    fileprivate static let dependency36 = Key<String>()
+    fileprivate static let dependency37 = Key<String>()
+    fileprivate static let dependency38 = Key<String>()
+    fileprivate static let dependency39 = Key<String>()
+    fileprivate static let dependency40 = Key<String>()
+    fileprivate static let dependency41 = Key<String>()
+    fileprivate static let dependency42 = Key<String>()
+    fileprivate static let dependency43 = Key<String>()
+    fileprivate static let dependency44 = Key<String>()
+    fileprivate static let dependency45 = Key<String>()
+    fileprivate static let dependency46 = Key<String>()
+    fileprivate static let dependency47 = Key<String>()
+    fileprivate static let dependency48 = Key<String>()
+    fileprivate static let dependency49 = Key<String>()
+}
+
+@Component(root: true)
+fileprivate struct RootComponent: Sendable {
+    @Provides(.dependency0)
+    var dependency0: String {
+        return get(.dependency25) + "Root0"
+    }
+    @Provides(.dependency1)
+    var dependency1: String {
+        return get(.dependency26) + "Root1"
+    }
+    @Provides(.dependency2)
+    var dependency2: String {
+        return get(.dependency27) + "Root2"
+    }
+    @Provides(.dependency3)
+    var dependency3: String {
+        return get(.dependency28) + "Root3"
+    }
+    @Provides(.dependency4)
+    var dependency4: String {
+        return get(.dependency29) + "Root4"
+    }
+    @Provides(.dependency5)
+    var dependency5: String {
+        return get(.dependency30) + "Root5"
+    }
+    @Provides(.dependency6)
+    var dependency6: String {
+        return get(.dependency31) + "Root6"
+    }
+    @Provides(.dependency7)
+    var dependency7: String {
+        return get(.dependency32) + "Root7"
+    }
+    @Provides(.dependency8)
+    var dependency8: String {
+        return get(.dependency33) + "Root8"
+    }
+    @Provides(.dependency9)
+    var dependency9: String {
+        return get(.dependency34) + "Root9"
+    }
+    @Provides(.dependency10)
+    var dependency10: String {
+        return get(.dependency35) + "Root10"
+    }
+    @Provides(.dependency11)
+    var dependency11: String {
+        return get(.dependency36) + "Root11"
+    }
+    @Provides(.dependency12)
+    var dependency12: String {
+        return get(.dependency37) + "Root12"
+    }
+    @Provides(.dependency13)
+    var dependency13: String {
+        return get(.dependency38) + "Root13"
+    }
+    @Provides(.dependency14)
+    var dependency14: String {
+        return get(.dependency39) + "Root14"
+    }
+    @Provides(.dependency15)
+    var dependency15: String {
+        return get(.dependency40) + "Root15"
+    }
+    @Provides(.dependency16)
+    var dependency16: String {
+        return get(.dependency41) + "Root16"
+    }
+    @Provides(.dependency17)
+    var dependency17: String {
+        return get(.dependency42) + "Root17"
+    }
+    @Provides(.dependency18)
+    var dependency18: String {
+        return get(.dependency43) + "Root18"
+    }
+    @Provides(.dependency19)
+    var dependency19: String {
+        return get(.dependency44) + "Root19"
+    }
+    @Provides(.dependency20)
+    var dependency20: String {
+        return get(.dependency45) + "Root20"
+    }
+    @Provides(.dependency21)
+    var dependency21: String {
+        return get(.dependency46) + "Root21"
+    }
+    @Provides(.dependency22)
+    var dependency22: String {
+        return get(.dependency47) + "Root22"
+    }
+    @Provides(.dependency23)
+    var dependency23: String {
+        return get(.dependency48) + "Root23"
+    }
+    @Provides(.dependency24)
+    var dependency24: String {
+        return get(.dependency49) + "Root24"
+    }
+    @Provides(.dependency25)
+    var dependency25: String {
+        "Root25"
+    }
+    @Provides(.dependency26)
+    var dependency26: String {
+        "Root26"
+    }
+    @Provides(.dependency27)
+    var dependency27: String {
+        "Root27"
+    }
+    @Provides(.dependency28)
+    var dependency28: String {
+        "Root28"
+    }
+    @Provides(.dependency29)
+    var dependency29: String {
+        "Root29"
+    }
+    @Provides(.dependency30)
+    var dependency30: String {
+        "Root30"
+    }
+    @Provides(.dependency31)
+    var dependency31: String {
+        "Root31"
+    }
+    @Provides(.dependency32)
+    var dependency32: String {
+        "Root32"
+    }
+    @Provides(.dependency33)
+    var dependency33: String {
+        "Root33"
+    }
+    @Provides(.dependency34)
+    var dependency34: String {
+        "Root34"
+    }
+    @Provides(.dependency35)
+    var dependency35: String {
+        "Root35"
+    }
+    @Provides(.dependency36)
+    var dependency36: String {
+        "Root36"
+    }
+    @Provides(.dependency37)
+    var dependency37: String {
+        "Root37"
+    }
+    @Provides(.dependency38)
+    var dependency38: String {
+        "Root38"
+    }
+    @Provides(.dependency39)
+    var dependency39: String {
+        "Root39"
+    }
+    @Provides(.dependency40)
+    var dependency40: String {
+        "Root40"
+    }
+    @Provides(.dependency41)
+    var dependency41: String {
+        "Root41"
+    }
+    @Provides(.dependency42)
+    var dependency42: String {
+        "Root42"
+    }
+    @Provides(.dependency43)
+    var dependency43: String {
+        "Root43"
+    }
+    @Provides(.dependency44)
+    var dependency44: String {
+        "Root44"
+    }
+    @Provides(.dependency45)
+    var dependency45: String {
+        "Root45"
+    }
+    @Provides(.dependency46)
+    var dependency46: String {
+        "Root46"
+    }
+    @Provides(.dependency47)
+    var dependency47: String {
+        "Root47"
+    }
+    @Provides(.dependency48)
+    var dependency48: String {
+        "Root48"
+    }
+    @Provides(.dependency49)
+    var dependency49: String {
+        "Root49"
+    }
+
+    var parentAComponent: ParentAComponent {
+        ParentAComponent(parent: self)
+    }
+
+    var parentBComponent: ParentBComponent {
+        ParentBComponent(parent: self)
+    }
+}
+
+@Component
+fileprivate struct ParentAComponent: Sendable {
+    @Provides(.dependency25)
+    var dependency25: String {
+        "ParentA25"
+    }
+    @Provides(.dependency26)
+    var dependency26: String {
+        "ParentA26"
+    }
+    @Provides(.dependency27)
+    var dependency27: String {
+        "ParentA27"
+    }
+    @Provides(.dependency28)
+    var dependency28: String {
+        "ParentA28"
+    }
+    @Provides(.dependency29)
+    var dependency29: String {
+        "ParentA29"
+    }
+
+    var childAComponent: ChildAComponent {
+        ChildAComponent(parent: self)
+    }
+
+    var childBComponent: ChildBComponent {
+        ChildBComponent(parent: self)
+    }
+}
+
+@Component
+fileprivate struct ParentBComponent: Sendable {
+    @Provides(.dependency25)
+    var dependency25: String {
+        return get(.dependency15) + get(.dependency35) + "ParentB25"
+    }
+    @Provides(.dependency26)
+    var dependency26: String {
+        return get(.dependency16) + get(.dependency36) + "ParentB26"
+    }
+    @Provides(.dependency27)
+    var dependency27: String {
+        return get(.dependency17) + get(.dependency37) + "ParentB27"
+    }
+    @Provides(.dependency28)
+    var dependency28: String {
+        return get(.dependency18) + get(.dependency38) + "ParentB28"
+    }
+    @Provides(.dependency29)
+    var dependency29: String {
+        return get(.dependency19) + get(.dependency39) + "ParentB29"
+    }
+    @Provides(.dependency30)
+    var dependency30: String {
+        return get(.dependency20) + get(.dependency40) + "ParentB30"
+    }
+    @Provides(.dependency31)
+    var dependency31: String {
+        return get(.dependency21) + get(.dependency41) + "ParentB31"
+    }
+    @Provides(.dependency32)
+    var dependency32: String {
+        return get(.dependency22) + get(.dependency42) + "ParentB32"
+    }
+    @Provides(.dependency33)
+    var dependency33: String {
+        return get(.dependency23) + get(.dependency43) + "ParentB33"
+    }
+    @Provides(.dependency34)
+    var dependency34: String {
+        return get(.dependency24) + get(.dependency44) + "ParentB34"
+    }
+
+    var childAComponent: ChildAComponent {
+        ChildAComponent(parent: self)
+    }
+
+    var childBComponent: ChildBComponent {
+        ChildBComponent(parent: self)
+    }
+}
+
+@Component
+fileprivate struct ChildAComponent: Sendable {
+    @Provides(.dependency0)
+    var dependency0: String {
+        "ChildA0"
+    }
+    @Provides(.dependency1)
+    var dependency1: String {
+        "ChildA1"
+    }
+    @Provides(.dependency2)
+    var dependency2: String {
+        "ChildA2"
+    }
+    @Provides(.dependency3)
+    var dependency3: String {
+        "ChildA3"
+    }
+    @Provides(.dependency4)
+    var dependency4: String {
+        "ChildA4"
+    }
+
+    func take() -> String {
+        return [get(.dependency0), get(.dependency1), get(.dependency2), get(.dependency3), get(.dependency4), get(.dependency5), get(.dependency6), get(.dependency7), get(.dependency8), get(.dependency9)].joined(separator: "-")
+    }
+}
+
+@Component
+fileprivate struct ChildBComponent: Sendable {
+    @Provides(.dependency5)
+    var dependency5: String {
+        return get(.dependency15) + get(.dependency25) + "ChildB5"
+    }
+    @Provides(.dependency6)
+    var dependency6: String {
+        return get(.dependency16) + get(.dependency26) + "ChildB6"
+    }
+    @Provides(.dependency7)
+    var dependency7: String {
+        return get(.dependency17) + get(.dependency27) + "ChildB7"
+    }
+    @Provides(.dependency8)
+    var dependency8: String {
+        return get(.dependency18) + get(.dependency28) + "ChildB8"
+    }
+    @Provides(.dependency9)
+    var dependency9: String {
+        return get(.dependency19) + get(.dependency29) + "ChildB9"
+    }
+
+    func take() -> String {
+        return [get(.dependency0), get(.dependency1), get(.dependency2), get(.dependency3), get(.dependency4), get(.dependency5), get(.dependency6), get(.dependency7), get(.dependency8), get(.dependency9)].joined(separator: "-")
+    }
+}

--- a/example/Sources/ExampleClient/RootComponent.swift
+++ b/example/Sources/ExampleClient/RootComponent.swift
@@ -6,11 +6,27 @@ extension AnyKey {
     static let client = Key<APIClient>()
 }
 
+struct DIRegistration<Component, T> {
+    var key: Key<T>
+    var provider: (Component, Container) -> T
+}
+
 @Component(root: true)
 struct RootComponent: Sendable {
     init() {
         session = URLSession(configuration: .default)
         initContainer(parent: self)
+    }
+
+    func getValue<T>(_ key: Key<T>) -> T {
+        switch key {
+        case .urlSession: session as! T
+        case .client: apiClient() as! T
+        case .userRepository: userRepository() as! T
+        case .imageRepository: imageRepository() as! T
+        default:
+            preconditionFailure("")
+        }
     }
 
     @Provides(.urlSession)
@@ -39,5 +55,44 @@ struct RootComponent: Sendable {
 
     func appComponent() -> AppComponent {
         AppComponent(parent: self)
+    }
+
+    private mutating func initContainer2(parent: some DI.Component) {
+        container = parent.container
+        let s6client13RootComponent0C0fMm_3setfMu_ = container.setter(for: .client)
+        s6client13RootComponent0C0fMm_3setfMu_(&container, __provide__client)
+        let s6client13RootComponent0C0fMm_3setfMu0_ = container.setter(for: .imageRepository)
+        s6client13RootComponent0C0fMm_3setfMu0_(&container, __provide__imageRepository)
+        let s6client13RootComponent0C0fMm_3setfMu1_ = container.setter(for: .urlSession)
+        s6client13RootComponent0C0fMm_3setfMu1_(&container, __provide__urlSession)
+        let s6client13RootComponent0C0fMm_3setfMu2_ = container.setter(for: .userRepository)
+        s6client13RootComponent0C0fMm_3setfMu2_(&container, __provide__userRepository)
+    }
+
+}
+
+/**
+    # 現状感じる課題
+    - せっかく値型なのだからカジュアルに直接mutatingしてその結果を使って値を取り出したい
+        - ex: rootComponent.configを書き換える
+    - 優先度がほしい。テスト用として差し込んだコンポーネントは下層コンポーネントで上書きを拒否してほしい。
+
+ */
+
+func f() {
+    let rootComponent = RootComponent()
+
+    let userRepositoryRef = RootComponent.userRepository
+
+    let appComponent = AppComponent(parent: rootComponent)
+    let appComponentParent: any Component = rootComponent
+
+//    appComponent.container.get(.userRepository)
+    
+    for component in [appComponent, appComponentParent] {
+        guard let c = component as? RootComponent else {
+            continue
+        }
+        userRepositoryRef(c)()
     }
 }

--- a/example/Sources/ExampleClient/RootComponent.swift
+++ b/example/Sources/ExampleClient/RootComponent.swift
@@ -18,17 +18,6 @@ struct RootComponent: Sendable {
         initContainer(parent: self)
     }
 
-    func getValue<T>(_ key: Key<T>) -> T {
-        switch key {
-        case .urlSession: session as! T
-        case .client: apiClient() as! T
-        case .userRepository: userRepository() as! T
-        case .imageRepository: imageRepository() as! T
-        default:
-            preconditionFailure("")
-        }
-    }
-
     @Provides(.urlSession)
     let session: URLSession
 
@@ -55,44 +44,5 @@ struct RootComponent: Sendable {
 
     func appComponent() -> AppComponent {
         AppComponent(parent: self)
-    }
-
-    private mutating func initContainer2(parent: some DI.Component) {
-        container = parent.container
-        let s6client13RootComponent0C0fMm_3setfMu_ = container.setter(for: .client)
-        s6client13RootComponent0C0fMm_3setfMu_(&container, __provide__client)
-        let s6client13RootComponent0C0fMm_3setfMu0_ = container.setter(for: .imageRepository)
-        s6client13RootComponent0C0fMm_3setfMu0_(&container, __provide__imageRepository)
-        let s6client13RootComponent0C0fMm_3setfMu1_ = container.setter(for: .urlSession)
-        s6client13RootComponent0C0fMm_3setfMu1_(&container, __provide__urlSession)
-        let s6client13RootComponent0C0fMm_3setfMu2_ = container.setter(for: .userRepository)
-        s6client13RootComponent0C0fMm_3setfMu2_(&container, __provide__userRepository)
-    }
-
-}
-
-/**
-    # 現状感じる課題
-    - せっかく値型なのだからカジュアルに直接mutatingしてその結果を使って値を取り出したい
-        - ex: rootComponent.configを書き換える
-    - 優先度がほしい。テスト用として差し込んだコンポーネントは下層コンポーネントで上書きを拒否してほしい。
-
- */
-
-func f() {
-    let rootComponent = RootComponent()
-
-    let userRepositoryRef = RootComponent.userRepository
-
-    let appComponent = AppComponent(parent: rootComponent)
-    let appComponentParent: any Component = rootComponent
-
-//    appComponent.container.get(.userRepository)
-    
-    for component in [appComponent, appComponentParent] {
-        guard let c = component as? RootComponent else {
-            continue
-        }
-        userRepositoryRef(c)()
     }
 }

--- a/example/Sources/ExampleClient/RootComponent.swift
+++ b/example/Sources/ExampleClient/RootComponent.swift
@@ -6,11 +6,6 @@ extension AnyKey {
     static let client = Key<APIClient>()
 }
 
-struct DIRegistration<Component, T> {
-    var key: Key<T>
-    var provider: (Component, Container) -> T
-}
-
 @Component(root: true)
 struct RootComponent: Sendable {
     init() {


### PR DESCRIPTION
Up until now, once a component was initialized, it couldn't be modified afterwards.
To enable a more natural usage in a Swift-like manner, I am updating the feature to allow properties to be changed later and still be retrievable via `Key`.