### PR TITLE
Without TaskLocal

### DIFF
--- a/Sources/DI/ComponentProtocol.swift
+++ b/Sources/DI/ComponentProtocol.swift
@@ -8,13 +8,8 @@ public protocol Component: Sendable {
 extension Component {
     @inlinable
     public func get<I>(_ key: Key<I>) -> I {
-        if let c = Components.current {
-            return container.get(key, with: c)
-        }
         let components = parents + CollectionOfOne<any Component>(self)
-        return Components.dollarCurrent.withValue(components) {
-            return container.get(key, with: components)
-        }
+        return container.get(key, with: components)
     }
 
     public mutating func initContainer(parent: (any DI.Component)?) {
@@ -29,12 +24,3 @@ extension Component {
         }
     }
 }
-
-@usableFromInline enum Components {
-    @TaskLocal
-    @usableFromInline static var current: [any Component]? = nil
-    @usableFromInline static var dollarCurrent: TaskLocal<[any Component]?> {
-        $current
-    }
-}
-

--- a/Sources/DI/Container.swift
+++ b/Sources/DI/Container.swift
@@ -7,7 +7,7 @@ public struct ComponentProvidingMetadata<C>: Sendable {
 //    @inlinable
 //    public mutating func set<I>(
 //        for key: Key<I>,
-//        _ provide: @escaping @Sendable (C) -> I
+//        _ provide: @escaping @Sendable (C, [any Component]) -> I
 //    ) {
 //        self.table[key] = FunctionDescriptor(ref: provide)
 //    }

--- a/Sources/DIMacros/Provides/ProvidesMacro.swift
+++ b/Sources/DIMacros/Provides/ProvidesMacro.swift
@@ -15,6 +15,7 @@ public struct ProvidesMacro: PeerMacro {
 
         let returnType: TypeSyntax
         let callExpr: TokenSyntax
+        let getterBlock: CodeBlockItemListSyntax?
         if let functionDecl = declaration.as(FunctionDeclSyntax.self) {
             guard let type = functionDecl.signature.returnClause?.type else {
                 throw MessageError("Expected a return type.")
@@ -24,6 +25,7 @@ public struct ProvidesMacro: PeerMacro {
             }
             returnType = type
             callExpr = "\(functionDecl.name.trimmed)()"
+            getterBlock = functionDecl.body?.statements
         } else if let varDecl = declaration.as(VariableDeclSyntax.self) {
             guard let binding = varDecl.bindings.first,
                   let type = binding.typeAnnotation?.type else {
@@ -31,19 +33,61 @@ public struct ProvidesMacro: PeerMacro {
             }
             returnType = type
             callExpr = "\(binding.pattern)"
+            getterBlock = binding.accessorBlock?.accessors.getter
         } else {
             throw MessageError("@Provides should be added to the 'func' or 'var' or 'let'.")
         }
 
-        return ["""
-        @Sendable private static func __provide_\(raw: funcNameSafe(keyIdentifier))(`self`: Self) -> \(returnType.trimmed) {
-            let instance = self.\(callExpr)
+        let f = try FunctionDeclSyntax("@Sendable private static func __provide_\(raw: funcNameSafe(keyIdentifier))(`self`: Self, components: [any Component]) -> \(returnType.trimmed)") {
+            if let getterBlock {
+                """
+                func `get`<I>(_ key: Key<I>) -> I {
+                    self.container.get(key, with: components)
+                }
+                """
+                """
+                let instance = { () -> \(returnType.trimmed) in
+                    \(SelfGetRewriter().visit(getterBlock).trimmed)
+                }()
+                """
+            } else {
+                "let instance = self.\(callExpr)"
+            }
+            """
             assert({
                 let check = DI.VariantChecker(\(raw: keyIdentifier))
                 return check(instance)
             }())
-            return instance
+            """
+            "return instance"
         }
-        """]
+        return [DeclSyntax(f)]
+    }
+}
+
+extension AccessorBlockSyntax.Accessors {
+    var `getter`: CodeBlockItemListSyntax? {
+        switch self {
+        case .getter(let syntax):
+            return syntax
+        case .accessors(let list):
+            return list.first { decl in
+                decl.accessorSpecifier.tokenKind == .keyword(.get)
+            }?.body?.statements
+        }
+    }
+}
+
+private class SelfGetRewriter: SyntaxRewriter {
+    override func visit(_ node: FunctionCallExprSyntax) -> ExprSyntax {
+        if node.calledExpression.trimmedDescription == "self.get" {
+            var node = node
+            node.calledExpression = ExprSyntax(
+                DeclReferenceExprSyntax(baseName: .identifier("get"))
+                    .with(\.leadingTrivia, node.calledExpression.leadingTrivia)
+            )
+            return ExprSyntax(node)
+        }
+        return super.visit(node)
     }
 }

--- a/Tests/DIMacrosTests/ComponentMacroTests.swift
+++ b/Tests/DIMacrosTests/ComponentMacroTests.swift
@@ -131,12 +131,17 @@ struct AnonymousComponent {
         URL(string: "https://foo.example.com/\(get(.apiVersion))/")!
     }
 
-    @Sendable private static func __provide_baseURLKey(`self`: Self) -> URL {
-        let instance = self.baseURL()
+    @Sendable private static func __provide_baseURLKey(`self`: Self, components: [any Component]) -> URL {
+        func `get`<I>(_ key: Key<I>) -> I {
+            self.container.get(key, with: components)
+        }
+        let instance = { () -> URL in
+            URL(string: "https://foo.example.com/\(get(.apiVersion))/")!
+        }()
         assert({
             let check = DI.VariantChecker(baseURLKey)
             return check(instance)
-        }())
+            }())
         return instance
     }
 

--- a/Tests/DIMacrosTests/ComponentMacroTests.swift
+++ b/Tests/DIMacrosTests/ComponentMacroTests.swift
@@ -131,7 +131,7 @@ struct AnonymousComponent {
         URL(string: "https://foo.example.com/\(get(.apiVersion))/")!
     }
 
-    @Sendable private static func __provide_baseURLKey(`self`: Self, components: [any Component]) -> URL {
+    @Sendable private static func __provide_baseURLKey(`self`: Self, components: [any DI.Component]) -> URL {
         func `get`<I>(_ key: Key<I>) -> I {
             self.container.get(key, with: components)
         }

--- a/Tests/DIMacrosTests/ComponentMacroTests.swift
+++ b/Tests/DIMacrosTests/ComponentMacroTests.swift
@@ -131,17 +131,21 @@ struct AnonymousComponent {
         URL(string: "https://foo.example.com/\(get(.apiVersion))/")!
     }
 
-    @Sendable private static func __provide_baseURLKey(`self`: Self, components: [any DI.Component]) -> URL {
+    private func __macro_local_10baseURLKeyfMu_(with components: [any DI.Component]) -> URL {
         func `get`<I>(_ key: Key<I>) -> I {
             self.container.get(key, with: components)
         }
-        let instance = { () -> URL in
+        return {
             URL(string: "https://foo.example.com/\(get(.apiVersion))/")!
         }()
+    }
+
+    @Sendable private static func __provide_baseURLKey(`self`: Self, components: [any DI.Component]) -> URL {
+        let instance = self.__macro_local_10baseURLKeyfMu_(with: components)
         assert({
             let check = DI.VariantChecker(baseURLKey)
             return check(instance)
-            }())
+        }())
         return instance
     }
 

--- a/Tests/DIMacrosTests/ProvidesMacroTests.swift
+++ b/Tests/DIMacrosTests/ProvidesMacroTests.swift
@@ -13,26 +13,33 @@ final class ProvidesMacroTests: XCTestCase {
 struct RootComponent {
     @Provides(.apiClient)
     func apiClient() -> APIClient {
-        APIClient()
+        let config = get(.apiConfig)
+        return APIClient(config: config)
     }
 }
 """, expandedSource: """
 struct RootComponent {
     func apiClient() -> APIClient {
-        APIClient()
+        let config = get(.apiConfig)
+        return APIClient(config: config)
     }
 
-    @Sendable private static func __provide__apiClient(`self`: Self, components: [any DI.Component]) -> APIClient {
+    private func __macro_local_10_apiClientfMu_(with components: [any DI.Component]) -> APIClient {
         func `get`<I>(_ key: Key<I>) -> I {
             self.container.get(key, with: components)
         }
-        let instance = { () -> APIClient in
-            APIClient()
+        return {
+            let config = get(.apiConfig)
+                    return APIClient(config: config)
         }()
+    }
+
+    @Sendable private static func __provide__apiClient(`self`: Self, components: [any DI.Component]) -> APIClient {
+        let instance = self.__macro_local_10_apiClientfMu_(with: components)
         assert({
             let check = DI.VariantChecker(.apiClient)
             return check(instance)
-            }())
+        }())
         return instance
     }
 }
@@ -80,7 +87,7 @@ struct RootComponent {
         assert({
             let check = DI.VariantChecker(.urlSession)
             return check(instance)
-            }())
+        }())
         return instance
     }
 }
@@ -105,7 +112,7 @@ struct RootComponent {
         assert({
             let check = DI.VariantChecker(.urlSession)
             return check(instance)
-            }())
+        }())
         return instance
     }
 }
@@ -128,17 +135,21 @@ struct RootComponent {
         .shared
     }
 
-    @Sendable private static func __provide__urlSession(`self`: Self, components: [any DI.Component]) -> URLSession {
+    private func __macro_local_11_urlSessionfMu_(with components: [any DI.Component]) -> URLSession {
         func `get`<I>(_ key: Key<I>) -> I {
             self.container.get(key, with: components)
         }
-        let instance = { () -> URLSession in
+        return {
             .shared
         }()
+    }
+
+    @Sendable private static func __provide__urlSession(`self`: Self, components: [any DI.Component]) -> URLSession {
+        let instance = self.__macro_local_11_urlSessionfMu_(with: components)
         assert({
             let check = DI.VariantChecker(.urlSession)
             return check(instance)
-            }())
+        }())
         return instance
     }
 }
@@ -184,7 +195,7 @@ struct RootComponent {
         assert({
             let check = DI.VariantChecker(.urlSession)
             return check(instance)
-            }())
+        }())
         return instance
     }
 }

--- a/Tests/DIMacrosTests/ProvidesMacroTests.swift
+++ b/Tests/DIMacrosTests/ProvidesMacroTests.swift
@@ -22,7 +22,7 @@ struct RootComponent {
         APIClient()
     }
 
-    @Sendable private static func __provide__apiClient(`self`: Self, components: [any Component]) -> APIClient {
+    @Sendable private static func __provide__apiClient(`self`: Self, components: [any DI.Component]) -> APIClient {
         func `get`<I>(_ key: Key<I>) -> I {
             self.container.get(key, with: components)
         }
@@ -75,7 +75,7 @@ struct RootComponent {
 struct RootComponent {
     let urlSession: URLSession
 
-    @Sendable private static func __provide__urlSession(`self`: Self, components: [any Component]) -> URLSession {
+    @Sendable private static func __provide__urlSession(`self`: Self, components: [any DI.Component]) -> URLSession {
         let instance = self.urlSession
         assert({
             let check = DI.VariantChecker(.urlSession)
@@ -100,7 +100,7 @@ expandedSource: """
 struct RootComponent {
     var urlSession: URLSession
 
-    @Sendable private static func __provide__urlSession(`self`: Self, components: [any Component]) -> URLSession {
+    @Sendable private static func __provide__urlSession(`self`: Self, components: [any DI.Component]) -> URLSession {
         let instance = self.urlSession
         assert({
             let check = DI.VariantChecker(.urlSession)
@@ -128,7 +128,7 @@ struct RootComponent {
         .shared
     }
 
-    @Sendable private static func __provide__urlSession(`self`: Self, components: [any Component]) -> URLSession {
+    @Sendable private static func __provide__urlSession(`self`: Self, components: [any DI.Component]) -> URLSession {
         func `get`<I>(_ key: Key<I>) -> I {
             self.container.get(key, with: components)
         }
@@ -170,12 +170,21 @@ struct RootComponent {
         }
     }
 
-    @Sendable private static func __provide__urlSession(`self`: Self) -> URLSession {
-        let instance = self.urlSession
+    private func __macro_local_11_urlSessionfMu_(with components: [any DI.Component]) -> URLSession {
+        func `get`<I>(_ key: Key<I>) -> I {
+            self.container.get(key, with: components)
+        }
+        return {
+            .shared
+        }()
+    }
+
+    @Sendable private static func __provide__urlSession(`self`: Self, components: [any DI.Component]) -> URLSession {
+        let instance = self.__macro_local_11_urlSessionfMu_(with: components)
         assert({
             let check = DI.VariantChecker(.urlSession)
             return check(instance)
-        }())
+            }())
         return instance
     }
 }

--- a/Tests/DITests/ComponentTests.swift
+++ b/Tests/DITests/ComponentTests.swift
@@ -5,6 +5,9 @@ extension AnyKey {
     fileprivate static let name = Key<String>()
     fileprivate static let age = Key<Int>()
     fileprivate static let message = Key<String>()
+    fileprivate static let getPatternA = Key<String>()
+    fileprivate static let getPatternB = Key<String>()
+    fileprivate static let getPatternC = Key<String>()
 }
 
 @Component(root: true)
@@ -36,6 +39,26 @@ fileprivate struct ParentComponent: Sendable {
         "I'm \(get(.name)), age=\(get(.age))"
     }
 
+    @Provides(.getPatternA)
+    var getPatternA: String {
+        self.get(.name) + get(.name)
+    }
+
+    @Provides(.getPatternB)
+    var getPatternB: String {
+        get {
+            "\(get(.name))\(self.get(.name))"
+        }
+    }
+
+    @Provides(.getPatternC)
+    func getPatternC() -> String {
+        return [
+            self.get(.name),
+            get(.name),
+        ].joined()
+    }
+
     var childComponent: ChildComponent {
         ChildComponent(parent: self)
     }
@@ -48,6 +71,10 @@ fileprivate struct ChildComponent: Sendable {
 
     func message() -> String {
         get(.message)
+    }
+
+    func getPatterns() -> (String, String, String) {
+        (get(.getPatternA), get(.getPatternB), get(.getPatternC))
     }
 }
 
@@ -66,5 +93,14 @@ final class ComponentTests: XCTestCase {
 
         child.name = "Foo"
         XCTAssertEqual(child.message(), "I'm Foo, age=42")
+    }
+
+    func testGetPatterns() {
+        var child = RootComponent().parentComponent.childComponent
+        child.name = "<>"
+        let (a, b, c) = child.getPatterns()
+        XCTAssertEqual(a, "<><>")
+        XCTAssertEqual(b, "<><>")
+        XCTAssertEqual(c, "<><>")
     }
 }

--- a/example/Sources/ExampleClient/RootComponent.swift
+++ b/example/Sources/ExampleClient/RootComponent.swift
@@ -24,14 +24,14 @@ struct RootComponent: Sendable {
     }
 
     @Provides(.userRepository)
-    func userRepository() -> some UserRepository {
+    func userRepository() -> any UserRepository {
         APIUserRepository(
             apiClient: get(.client)
         )
     }
 
-    @Provides(DI.AnyKey.imageRepository)
-    func imageRepository() -> some ImageRepository {
+    
+    func imageRepository() -> any ImageRepository {
         NetworkImageRepository(
             urlSession: get(AnyKey.urlSession)
         )

--- a/example/Sources/ExampleClient/RootComponent.swift
+++ b/example/Sources/ExampleClient/RootComponent.swift
@@ -30,7 +30,7 @@ struct RootComponent: Sendable {
         )
     }
 
-    
+    @Provides(DI.AnyKey.imageRepository)
     func imageRepository() -> any ImageRepository {
         NetworkImageRepository(
             urlSession: get(AnyKey.urlSession)


### PR DESCRIPTION
The current `get` implementation uses `TaskLocal` storage for propagating the current `components`.
`TaskLocal` uses thread-local storage when there is no `Task` context. This approach is sufficiently fast but introduces some overhead.

This PR introduces a new implementation to propagate the `components` as a function argument using a shadow `get` method.