### PR TITLE
Add priority argument

### DIFF
--- a/Sources/DI/Macros.swift
+++ b/Sources/DI/Macros.swift
@@ -18,4 +18,7 @@ public macro Component(root: Bool? = nil) = #externalMacro(module: "DIMacros", t
     peer,
     names: arbitrary
 )
-public macro Provides<I>(_ key: Key<I>) = #externalMacro(module: "DIMacros", type: "ProvidesMacro")
+public macro Provides<I>(
+    _ key: Key<I>,
+    priority: Priority = .default
+) = #externalMacro(module: "DIMacros", type: "ProvidesMacro")

--- a/Sources/DI/Priority.swift
+++ b/Sources/DI/Priority.swift
@@ -1,0 +1,19 @@
+public struct Priority: Comparable, Sendable {
+    var rawValue: Int
+
+    public static func < (lhs: Priority, rhs: Priority) -> Bool {
+        return lhs.rawValue < rhs.rawValue
+    }
+
+    public static var `default`: Priority {
+        return .init(rawValue: 0)
+    }
+
+    public static var test: Priority {
+        return .init(rawValue: 10)
+    }
+
+    public static func custom(_ value: Int) -> Priority {
+        return .init(rawValue: value)
+    }
+}

--- a/Tests/DIMacrosTests/CallArgumentsVisitorTests.swift
+++ b/Tests/DIMacrosTests/CallArgumentsVisitorTests.swift
@@ -6,7 +6,7 @@ import XCTest
 final class CallArgumentsVisitorTests: XCTestCase {
     func testBasic() {
         let provide = FoundProvides(
-            key: .init(".foo" as ExprSyntax),
+            arguments: .init(key: .init(".foo" as ExprSyntax)),
             callExpression: "getFoo()"
         )
 
@@ -28,7 +28,7 @@ final class CallArgumentsVisitorTests: XCTestCase {
 
     func testSelf() {
         let provide = FoundProvides(
-            key: .init(".foo" as ExprSyntax),
+            arguments: .init(key: .init(".foo" as ExprSyntax)),
             callExpression: "getFoo()"
         )
 
@@ -50,7 +50,7 @@ final class CallArgumentsVisitorTests: XCTestCase {
 
     func testMemberAccess() {
         let provide = FoundProvides(
-            key: .init(".foo" as ExprSyntax),
+            arguments: .init(key: .init(".foo" as ExprSyntax)),
             callExpression: "getFoo()"
         )
 
@@ -72,7 +72,7 @@ final class CallArgumentsVisitorTests: XCTestCase {
 
     func testConfusingPrefix() {
         let provide = FoundProvides(
-            key: .init(".foo" as ExprSyntax),
+            arguments: .init(key: .init(".foo" as ExprSyntax)),
             callExpression: "foo"
         )
 
@@ -87,7 +87,7 @@ final class CallArgumentsVisitorTests: XCTestCase {
 
     func testEscapeByTuple() {
         let provide = FoundProvides(
-            key: .init(".foo" as ExprSyntax),
+            arguments: .init(key: .init(".foo" as ExprSyntax)),
             callExpression: "foo"
         )
 

--- a/Tests/DIMacrosTests/ComponentMacroTests.swift
+++ b/Tests/DIMacrosTests/ComponentMacroTests.swift
@@ -169,7 +169,7 @@ struct AnonymousComponent {
 
     static let providingMetadata: ComponentProvidingMetadata<Self> = {
         var metadata = ComponentProvidingMetadata<Self>()
-        let __macro_local_3setfMu_ = metadata.setter(for: baseURLKey)
+        let __macro_local_3setfMu_ = metadata.setter(for: baseURLKey, priority: .default)
         __macro_local_3setfMu_(&metadata, __provide_baseURLKey)
         return metadata
     }()
@@ -389,10 +389,10 @@ struct MyComponent {
 
     static let providingMetadata: ComponentProvidingMetadata<Self> = {
         var metadata = ComponentProvidingMetadata<Self>()
-        let __macro_local_3setfMu_ = metadata.setter(for: .bar)
-        __macro_local_3setfMu_(&metadata, __provide__bar)
-        let __macro_local_3setfMu0_ = metadata.setter(for: .foo)
-        __macro_local_3setfMu0_(&metadata, __provide__foo)
+        let __macro_local_3setfMu_ = metadata.setter(for: .foo, priority: .default)
+        __macro_local_3setfMu_(&metadata, __provide__foo)
+        let __macro_local_3setfMu0_ = metadata.setter(for: .bar, priority: .default)
+        __macro_local_3setfMu0_(&metadata, __provide__bar)
         return metadata
     }()
 }
@@ -438,6 +438,59 @@ diagnostics: [
         ]
     ),
 ],
+macros: ["Component": ComponentMacro.self]
+        )
+    }
+
+    func testPriority() throws {
+        assertMacroExpansion(
+#"""
+@Component
+struct MyComponent {
+    @Provides(.foo, priority: .test)
+    let foo: Foo
+
+    @Provides(.bar, priority: .custom(2))
+    func bar() -> Bar {
+        Bar()
+    }
+}
+"""#,
+expandedSource: #"""
+struct MyComponent {
+    @Provides(.foo, priority: .test)
+    let foo: Foo
+
+    @Provides(.bar, priority: .custom(2))
+    func bar() -> Bar {
+        Bar()
+    }
+
+    static var requirements: Set<DI.AnyKey> {
+        []
+    }
+
+    var container = DI.Container()
+
+    var parents = [any DI.Component] ()
+
+    init(parent: some DI.Component) {
+        initContainer(parent: parent)
+    }
+
+    static let providingMetadata: ComponentProvidingMetadata<Self> = {
+        var metadata = ComponentProvidingMetadata<Self>()
+        let __macro_local_3setfMu_ = metadata.setter(for: .foo, priority: .test)
+        __macro_local_3setfMu_(&metadata, __provide__foo)
+        let __macro_local_3setfMu0_ = metadata.setter(for: .bar, priority: .custom(2))
+        __macro_local_3setfMu0_(&metadata, __provide__bar)
+        return metadata
+    }()
+}
+
+extension MyComponent: DI.Component {
+}
+"""#,
 macros: ["Component": ComponentMacro.self]
         )
     }

--- a/Tests/DITests/ComponentTests.swift
+++ b/Tests/DITests/ComponentTests.swift
@@ -8,6 +8,7 @@ extension AnyKey {
     fileprivate static let getPatternA = Key<String>()
     fileprivate static let getPatternB = Key<String>()
     fileprivate static let getPatternC = Key<String>()
+    fileprivate static let priorityTest = Key<Int>()
 }
 
 @Component(root: true)
@@ -20,6 +21,13 @@ fileprivate struct RootComponent: Sendable {
     @Provides(.age)
     func age() -> Int {
         42
+    }
+
+    @Provides(.priorityTest, priority: .custom(10))
+    let priorityTest: Int = 10
+
+    func getPriority() -> Int {
+        get(.priorityTest)
     }
 
     var parentComponent: ParentComponent {
@@ -59,6 +67,13 @@ fileprivate struct ParentComponent: Sendable {
         ].joined()
     }
 
+    @Provides(.priorityTest, priority: .custom(20))
+    let priorityTest: Int = 20
+
+    func getPriority() -> Int {
+        get(.priorityTest)
+    }
+
     var childComponent: ChildComponent {
         ChildComponent(parent: self)
     }
@@ -75,6 +90,13 @@ fileprivate struct ChildComponent: Sendable {
 
     func getPatterns() -> (String, String, String) {
         (get(.getPatternA), get(.getPatternB), get(.getPatternC))
+    }
+
+    @Provides(.priorityTest, priority: .custom(0))
+    let priorityTest: Int = 0
+
+    func getPriority() -> Int {
+        get(.priorityTest)
     }
 }
 
@@ -102,5 +124,14 @@ final class ComponentTests: XCTestCase {
         XCTAssertEqual(a, "<><>")
         XCTAssertEqual(b, "<><>")
         XCTAssertEqual(c, "<><>")
+    }
+
+    func testPriority() {
+        let root = RootComponent()
+        XCTAssertEqual(root.getPriority(), 10)
+        let parent = root.parentComponent
+        XCTAssertEqual(parent.getPriority(), 20)
+        let child = parent.childComponent
+        XCTAssertEqual(child.getPriority(), 20)
     }
 }


### PR DESCRIPTION
Add `priority:` argument to `@Provides` macro.

Higher priorities are no longer overridden by lower ones.