### PR TITLE
Rename to bind and update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ component.printName() // TestComponent
 
 ### Manually Bind Value
 
-By using `bind(value:forKey:)`, you can procedurally override values.
+By using `bind(_:forKey:)`, you can procedurally override values.
 
 ```swift
 @Component
@@ -118,7 +118,7 @@ struct ChildComponent {
 
 var component = ChildComponent(parent: ParentComponent())
 component.printProfile() // name=ChildComponent, age=42
-component.bind(value: 10, forKey: .age)
+component.bind(10, forKey: .age)
 component.printProfile() // name=ChildComponent, age=10
 ```
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Swift DI is a component-based DI (Dependency Injection) library designed specifi
 The DI container is implemented as a value type to take advantage of Swift's features.
 No external executables are needed; it is implemented using standard Swift language features and macros.
 By using only Swift features, the DI container can easily adapt to new versions of Swift, and users can also extend it to customize behaviors.
-Multi-module compliance, Sendable conforming, and instance overwriting by lower components are supported.
+Multi-module compliance, Sendable conforming, and instance overwriting are supported.
 
 # Getting Started
 
@@ -65,6 +65,61 @@ struct ChildComponent {
         print(get(.foo)) // => Foo(name: "ChildComponent")
     }
 }
+```
+
+### Use Priority
+
+When `priority` is set, values with a lower priority will not overwrite those with a higher priority.
+
+```swift
+@Component(root: true)
+struct TestComponent {
+    @Provides(.name, priority: .test)
+    var name: String { "TestComponent" }
+}
+
+@Component
+struct AppComponent {
+    @Provides(.name, priority: .default)
+    var name: String { "AppComponent" }
+
+    func printName() {
+        print(get(.name))
+    }
+}
+
+let component = AppComponent(parent: TestComponent())
+component.printName() // TestComponent
+```
+
+### Manually Bind Value
+
+By using `bind(value:forKey:)`, you can procedurally override values.
+
+```swift
+@Component
+struct ParentComponent {
+    @Provides(.name)
+    var name: String = "ParentComponent"
+
+    @Provides(.age)
+    var age: Int = 42
+}
+
+@Component
+struct ChildComponent {
+    @Provides(.name)
+    var name: String = "ChildComponent"
+
+    func printProfile() {
+        print("name=\(get(.name)), age=\(get(.age))")
+    }
+}
+
+var component = ChildComponent(parent: ParentComponent())
+component.printProfile() // name=ChildComponent, age=42
+component.bind(value: 10, forKey: .age)
+component.printProfile() // name=ChildComponent, age=10
 ```
 
 # Frequently Asked Questions

--- a/Sources/DI/ComponentProtocol.swift
+++ b/Sources/DI/ComponentProtocol.swift
@@ -13,9 +13,9 @@ extension Component {
     }
 
     @inlinable
-    public mutating func override<I: Sendable>(
-        _ key: Key<I>,
+    public mutating func bind<I: Sendable>(
         value: I,
+        forKey key: Key<I>,
         priority: Priority = .default
     ) {
         for i in parents.indices {

--- a/Sources/DI/ComponentProtocol.swift
+++ b/Sources/DI/ComponentProtocol.swift
@@ -14,7 +14,7 @@ extension Component {
 
     @inlinable
     public mutating func bind<I: Sendable>(
-        value: I,
+        _ value: I,
         forKey key: Key<I>,
         priority: Priority = .default
     ) {

--- a/Tests/DITests/ComponentTests.swift
+++ b/Tests/DITests/ComponentTests.swift
@@ -135,35 +135,36 @@ final class ComponentTests: XCTestCase {
         XCTAssertEqual(child.getPriority(), 20)
     }
 
-    func testOverride() {
+    func testBind() {
         var parent = RootComponent().parentComponent
         XCTAssertEqual(parent.message, "I'm ParentComponent, age=42")
 
         // Override without/with priority
-        parent.override(.name, value: "Overridden")
-        parent.override(.age, value: -1, priority: .custom(-1))
+        parent.bind(value: "Overridden", forKey: .name)
+        parent.bind(value: -1, forKey: .age, priority: .custom(-1))
         XCTAssertEqual(parent.message, "I'm Overridden, age=42")
-        parent.override(.age, value: 99)
+        parent.bind(value: 99, forKey: .age)
         XCTAssertEqual(parent.message, "I'm Overridden, age=99")
     }
 
-    func testOverrideWithInheritance() {
+    func testBindWithInheritance() {
         var parent = RootComponent().parentComponent
-        parent.override(.name, value: "Overridden")
+        parent.bind(value: "Overridden", forKey: .name)
 
         // The .name property becomes the child component’s one, but .age remains overridden because the child component does not provide the .age property.
         var child = parent.childComponent
         XCTAssertEqual(child.message(), "I'm ChildComponent, age=42")
 
-        parent.override(.name, value: "Overridden", priority: .test)
+        parent.bind(value: "Overridden", forKey: .name, priority: .test)
+        parent.bi
         child = parent.childComponent
         XCTAssertEqual(child.message(), "I'm Overridden, age=42")
     }
 
-    func testOverrideInChildAndUseInParent() {
+    func testBind1InChildAndUseInParent() {
         var child = RootComponent().parentComponent.childComponent
         XCTAssertEqual(child.message(), "I'm ChildComponent, age=42")
-        child.override(.name, value: "Overridden")
+        child.bind(value: "Overridden", forKey: .name)
         XCTAssertEqual(child.message(), "I'm Overridden, age=42")
     }
 }

--- a/Tests/DITests/ComponentTests.swift
+++ b/Tests/DITests/ComponentTests.swift
@@ -140,22 +140,22 @@ final class ComponentTests: XCTestCase {
         XCTAssertEqual(parent.message, "I'm ParentComponent, age=42")
 
         // Override without/with priority
-        parent.bind(value: "Overridden", forKey: .name)
-        parent.bind(value: -1, forKey: .age, priority: .custom(-1))
+        parent.bind("Overridden", forKey: .name)
+        parent.bind(-1, forKey: .age, priority: .custom(-1))
         XCTAssertEqual(parent.message, "I'm Overridden, age=42")
-        parent.bind(value: 99, forKey: .age)
+        parent.bind(99, forKey: .age)
         XCTAssertEqual(parent.message, "I'm Overridden, age=99")
     }
 
     func testBindWithInheritance() {
         var parent = RootComponent().parentComponent
-        parent.bind(value: "Overridden", forKey: .name)
+        parent.bind("Overridden", forKey: .name)
 
         // The .name property becomes the child component’s one, but .age remains overridden because the child component does not provide the .age property.
         var child = parent.childComponent
         XCTAssertEqual(child.message(), "I'm ChildComponent, age=42")
 
-        parent.bind(value: "Overridden", forKey: .name, priority: .test)
+        parent.bind("Overridden", forKey: .name, priority: .test)
         child = parent.childComponent
         XCTAssertEqual(child.message(), "I'm Overridden, age=42")
     }
@@ -163,7 +163,7 @@ final class ComponentTests: XCTestCase {
     func testBindInChildAndUseInParent() {
         var child = RootComponent().parentComponent.childComponent
         XCTAssertEqual(child.message(), "I'm ChildComponent, age=42")
-        child.bind(value: "Overridden", forKey: .name)
+        child.bind("Overridden", forKey: .name)
         XCTAssertEqual(child.message(), "I'm Overridden, age=42")
     }
 }

--- a/Tests/DITests/ComponentTests.swift
+++ b/Tests/DITests/ComponentTests.swift
@@ -156,12 +156,11 @@ final class ComponentTests: XCTestCase {
         XCTAssertEqual(child.message(), "I'm ChildComponent, age=42")
 
         parent.bind(value: "Overridden", forKey: .name, priority: .test)
-        parent.bi
         child = parent.childComponent
         XCTAssertEqual(child.message(), "I'm Overridden, age=42")
     }
 
-    func testBind1InChildAndUseInParent() {
+    func testBindInChildAndUseInParent() {
         var child = RootComponent().parentComponent.childComponent
         XCTAssertEqual(child.message(), "I'm ChildComponent, age=42")
         child.bind(value: "Overridden", forKey: .name)


### PR DESCRIPTION
Rename `override(_:value:)` to `bind(value:forKey:)`.
and update README.md