### PR TITLE
Fix error when using `get` inside not @Provider annotated function

### DIFF
--- a/Sources/DI/ComponentProtocol.swift
+++ b/Sources/DI/ComponentProtocol.swift
@@ -7,11 +7,8 @@ public protocol Component: Sendable {
 
 extension Component {
     @inlinable
-    public func get<I>(
-        _ key: Key<I>,
-        with components: [any Component]? = Components.current
-    ) -> I {
-        if let components {
+    public func get<I>(_ key: Key<I>) -> I {
+        if let components = Components.current {
             return container.get(key, with: components)
         }
         let components = parents + CollectionOfOne<any Component>(self)

--- a/Sources/DIMacros/Provides/ProvidesMacro.swift
+++ b/Sources/DIMacros/Provides/ProvidesMacro.swift
@@ -14,8 +14,7 @@ public struct ProvidesMacro: PeerMacro {
         let keyIdentifier = argument.key.description
 
         let returnType: TypeSyntax
-        var callExpr: TokenSyntax
-        let getterBlock: CodeBlockItemListSyntax?
+        let callExpr: TokenSyntax
         if let functionDecl = declaration.as(FunctionDeclSyntax.self) {
             guard let type = functionDecl.signature.returnClause?.type else {
                 throw MessageError("Expected a return type.")
@@ -25,7 +24,6 @@ public struct ProvidesMacro: PeerMacro {
             }
             returnType = type
             callExpr = "\(functionDecl.name.trimmed)()"
-            getterBlock = functionDecl.body?.statements
         } else if let varDecl = declaration.as(VariableDeclSyntax.self) {
             guard let binding = varDecl.bindings.first,
                   let type = binding.typeAnnotation?.type else {
@@ -33,28 +31,13 @@ public struct ProvidesMacro: PeerMacro {
             }
             returnType = type
             callExpr = "\(binding.pattern)"
-            getterBlock = binding.accessorBlock?.accessors.getter
         } else {
             throw MessageError("@Provides should be added to the 'func' or 'var' or 'let'.")
         }
 
         let keyFuncName = funcNameSafe(keyIdentifier)
-        var result: [DeclSyntax] = []
 
-        if let getterBlock {
-            let getterFuncName = context.makeUniqueName(keyFuncName)
-            callExpr = "\(getterFuncName)(with: components)"
-            result.append("""
-            private func \(getterFuncName)(with components: [any DI.Component]) -> \(returnType.trimmed) {
-                func `get`<I>(_ key: Key<I>) -> I {
-                    self.container.get(key, with: components)
-                }
-                return {
-                    \(SelfGetRewriter().visit(getterBlock).trimmed)
-                }()
-            }
-            """)
-        }
+        var result: [DeclSyntax] = []
         result.append("""
         @Sendable private static func __provide_\(raw: keyFuncName)(`self`: Self, components: [any DI.Component]) -> \(returnType.trimmed) {
             let instance = self.\(callExpr)
@@ -66,32 +49,5 @@ public struct ProvidesMacro: PeerMacro {
         }
         """)
         return result
-    }
-}
-
-extension AccessorBlockSyntax.Accessors {
-    var `getter`: CodeBlockItemListSyntax? {
-        switch self {
-        case .getter(let syntax):
-            return syntax
-        case .accessors(let list):
-            return list.first { decl in
-                decl.accessorSpecifier.tokenKind == .keyword(.get)
-            }?.body?.statements
-        }
-    }
-}
-
-private class SelfGetRewriter: SyntaxRewriter {
-    override func visit(_ node: FunctionCallExprSyntax) -> ExprSyntax {
-        if node.calledExpression.trimmedDescription == "self.get" {
-            var node = node
-            node.calledExpression = ExprSyntax(
-                DeclReferenceExprSyntax(baseName: .identifier("get"))
-                    .with(\.leadingTrivia, node.calledExpression.leadingTrivia)
-            )
-            return ExprSyntax(node)
-        }
-        return super.visit(node)
     }
 }

--- a/Sources/DIMacros/Provides/ProvidesMacro.swift
+++ b/Sources/DIMacros/Provides/ProvidesMacro.swift
@@ -47,7 +47,7 @@ public struct ProvidesMacro: PeerMacro {
             result.append("""
             private func \(getterFuncName)(with components: [any DI.Component]) -> \(returnType.trimmed) {
                 func `get`<I>(_ key: Key<I>) -> I {
-                    self.container.get(key, with: components)
+                    self.get(key, with: components)
                 }
                 return {
                     \(SelfGetRewriter().visit(getterBlock).trimmed)

--- a/Sources/DIMacros/Provides/ProvidesMacro.swift
+++ b/Sources/DIMacros/Provides/ProvidesMacro.swift
@@ -47,7 +47,7 @@ public struct ProvidesMacro: PeerMacro {
             result.append("""
             private func \(getterFuncName)(with components: [any DI.Component]) -> \(returnType.trimmed) {
                 func `get`<I>(_ key: Key<I>) -> I {
-                    self.get(key, with: components)
+                    self.container.get(key, with: components)
                 }
                 return {
                     \(SelfGetRewriter().visit(getterBlock).trimmed)

--- a/Sources/DIMacros/Provides/ProvidesMacro.swift
+++ b/Sources/DIMacros/Provides/ProvidesMacro.swift
@@ -39,7 +39,7 @@ public struct ProvidesMacro: PeerMacro {
 
         var result: [DeclSyntax] = []
         result.append("""
-        @Sendable private static func __provide_\(raw: keyFuncName)(`self`: Self, components: [any DI.Component]) -> \(returnType.trimmed) {
+        @Sendable private static func __provide_\(raw: keyFuncName)(`self`: Self) -> \(returnType.trimmed) {
             let instance = self.\(callExpr)
             assert({
                 let check = DI.VariantChecker(\(raw: keyIdentifier))

--- a/Tests/DIMacrosTests/ComponentMacroTests.swift
+++ b/Tests/DIMacrosTests/ComponentMacroTests.swift
@@ -131,7 +131,7 @@ struct AnonymousComponent {
         URL(string: "https://foo.example.com/\(get(.apiVersion))/")!
     }
 
-    @Sendable private static func __provide_baseURLKey(`self`: Self, components: [any DI.Component]) -> URL {
+    @Sendable private static func __provide_baseURLKey(`self`: Self) -> URL {
         let instance = self.baseURL()
         assert({
             let check = DI.VariantChecker(baseURLKey)

--- a/Tests/DIMacrosTests/ComponentMacroTests.swift
+++ b/Tests/DIMacrosTests/ComponentMacroTests.swift
@@ -133,7 +133,7 @@ struct AnonymousComponent {
 
     private func __macro_local_10baseURLKeyfMu_(with components: [any DI.Component]) -> URL {
         func `get`<I>(_ key: Key<I>) -> I {
-            self.get(key, with: components)
+            self.container.get(key, with: components)
         }
         return {
             URL(string: "https://foo.example.com/\(get(.apiVersion))/")!

--- a/Tests/DIMacrosTests/ComponentMacroTests.swift
+++ b/Tests/DIMacrosTests/ComponentMacroTests.swift
@@ -131,17 +131,8 @@ struct AnonymousComponent {
         URL(string: "https://foo.example.com/\(get(.apiVersion))/")!
     }
 
-    private func __macro_local_10baseURLKeyfMu_(with components: [any DI.Component]) -> URL {
-        func `get`<I>(_ key: Key<I>) -> I {
-            self.container.get(key, with: components)
-        }
-        return {
-            URL(string: "https://foo.example.com/\(get(.apiVersion))/")!
-        }()
-    }
-
     @Sendable private static func __provide_baseURLKey(`self`: Self, components: [any DI.Component]) -> URL {
-        let instance = self.__macro_local_10baseURLKeyfMu_(with: components)
+        let instance = self.baseURL()
         assert({
             let check = DI.VariantChecker(baseURLKey)
             return check(instance)

--- a/Tests/DIMacrosTests/ComponentMacroTests.swift
+++ b/Tests/DIMacrosTests/ComponentMacroTests.swift
@@ -133,7 +133,7 @@ struct AnonymousComponent {
 
     private func __macro_local_10baseURLKeyfMu_(with components: [any DI.Component]) -> URL {
         func `get`<I>(_ key: Key<I>) -> I {
-            self.container.get(key, with: components)
+            self.get(key, with: components)
         }
         return {
             URL(string: "https://foo.example.com/\(get(.apiVersion))/")!

--- a/Tests/DIMacrosTests/ProvidesMacroTests.swift
+++ b/Tests/DIMacrosTests/ProvidesMacroTests.swift
@@ -24,18 +24,8 @@ struct RootComponent {
         return APIClient(config: config)
     }
 
-    private func __macro_local_10_apiClientfMu_(with components: [any DI.Component]) -> APIClient {
-        func `get`<I>(_ key: Key<I>) -> I {
-            self.container.get(key, with: components)
-        }
-        return {
-            let config = get(.apiConfig)
-                    return APIClient(config: config)
-        }()
-    }
-
     @Sendable private static func __provide__apiClient(`self`: Self, components: [any DI.Component]) -> APIClient {
-        let instance = self.__macro_local_10_apiClientfMu_(with: components)
+        let instance = self.apiClient()
         assert({
             let check = DI.VariantChecker(.apiClient)
             return check(instance)
@@ -135,17 +125,8 @@ struct RootComponent {
         .shared
     }
 
-    private func __macro_local_11_urlSessionfMu_(with components: [any DI.Component]) -> URLSession {
-        func `get`<I>(_ key: Key<I>) -> I {
-            self.container.get(key, with: components)
-        }
-        return {
-            .shared
-        }()
-    }
-
     @Sendable private static func __provide__urlSession(`self`: Self, components: [any DI.Component]) -> URLSession {
-        let instance = self.__macro_local_11_urlSessionfMu_(with: components)
+        let instance = self.urlSession
         assert({
             let check = DI.VariantChecker(.urlSession)
             return check(instance)
@@ -181,17 +162,8 @@ struct RootComponent {
         }
     }
 
-    private func __macro_local_11_urlSessionfMu_(with components: [any DI.Component]) -> URLSession {
-        func `get`<I>(_ key: Key<I>) -> I {
-            self.container.get(key, with: components)
-        }
-        return {
-            .shared
-        }()
-    }
-
     @Sendable private static func __provide__urlSession(`self`: Self, components: [any DI.Component]) -> URLSession {
-        let instance = self.__macro_local_11_urlSessionfMu_(with: components)
+        let instance = self.urlSession
         assert({
             let check = DI.VariantChecker(.urlSession)
             return check(instance)

--- a/Tests/DIMacrosTests/ProvidesMacroTests.swift
+++ b/Tests/DIMacrosTests/ProvidesMacroTests.swift
@@ -26,7 +26,7 @@ struct RootComponent {
 
     private func __macro_local_10_apiClientfMu_(with components: [any DI.Component]) -> APIClient {
         func `get`<I>(_ key: Key<I>) -> I {
-            self.container.get(key, with: components)
+            self.get(key, with: components)
         }
         return {
             let config = get(.apiConfig)
@@ -137,7 +137,7 @@ struct RootComponent {
 
     private func __macro_local_11_urlSessionfMu_(with components: [any DI.Component]) -> URLSession {
         func `get`<I>(_ key: Key<I>) -> I {
-            self.container.get(key, with: components)
+            self.get(key, with: components)
         }
         return {
             .shared
@@ -183,7 +183,7 @@ struct RootComponent {
 
     private func __macro_local_11_urlSessionfMu_(with components: [any DI.Component]) -> URLSession {
         func `get`<I>(_ key: Key<I>) -> I {
-            self.container.get(key, with: components)
+            self.get(key, with: components)
         }
         return {
             .shared

--- a/Tests/DIMacrosTests/ProvidesMacroTests.swift
+++ b/Tests/DIMacrosTests/ProvidesMacroTests.swift
@@ -24,7 +24,7 @@ struct RootComponent {
         return APIClient(config: config)
     }
 
-    @Sendable private static func __provide__apiClient(`self`: Self, components: [any DI.Component]) -> APIClient {
+    @Sendable private static func __provide__apiClient(`self`: Self) -> APIClient {
         let instance = self.apiClient()
         assert({
             let check = DI.VariantChecker(.apiClient)
@@ -72,7 +72,7 @@ struct RootComponent {
 struct RootComponent {
     let urlSession: URLSession
 
-    @Sendable private static func __provide__urlSession(`self`: Self, components: [any DI.Component]) -> URLSession {
+    @Sendable private static func __provide__urlSession(`self`: Self) -> URLSession {
         let instance = self.urlSession
         assert({
             let check = DI.VariantChecker(.urlSession)
@@ -97,7 +97,7 @@ expandedSource: """
 struct RootComponent {
     var urlSession: URLSession
 
-    @Sendable private static func __provide__urlSession(`self`: Self, components: [any DI.Component]) -> URLSession {
+    @Sendable private static func __provide__urlSession(`self`: Self) -> URLSession {
         let instance = self.urlSession
         assert({
             let check = DI.VariantChecker(.urlSession)
@@ -125,7 +125,7 @@ struct RootComponent {
         .shared
     }
 
-    @Sendable private static func __provide__urlSession(`self`: Self, components: [any DI.Component]) -> URLSession {
+    @Sendable private static func __provide__urlSession(`self`: Self) -> URLSession {
         let instance = self.urlSession
         assert({
             let check = DI.VariantChecker(.urlSession)
@@ -162,7 +162,7 @@ struct RootComponent {
         }
     }
 
-    @Sendable private static func __provide__urlSession(`self`: Self, components: [any DI.Component]) -> URLSession {
+    @Sendable private static func __provide__urlSession(`self`: Self) -> URLSession {
         let instance = self.urlSession
         assert({
             let check = DI.VariantChecker(.urlSession)

--- a/Tests/DIMacrosTests/ProvidesMacroTests.swift
+++ b/Tests/DIMacrosTests/ProvidesMacroTests.swift
@@ -26,7 +26,7 @@ struct RootComponent {
 
     private func __macro_local_10_apiClientfMu_(with components: [any DI.Component]) -> APIClient {
         func `get`<I>(_ key: Key<I>) -> I {
-            self.get(key, with: components)
+            self.container.get(key, with: components)
         }
         return {
             let config = get(.apiConfig)
@@ -137,7 +137,7 @@ struct RootComponent {
 
     private func __macro_local_11_urlSessionfMu_(with components: [any DI.Component]) -> URLSession {
         func `get`<I>(_ key: Key<I>) -> I {
-            self.get(key, with: components)
+            self.container.get(key, with: components)
         }
         return {
             .shared
@@ -183,7 +183,7 @@ struct RootComponent {
 
     private func __macro_local_11_urlSessionfMu_(with components: [any DI.Component]) -> URLSession {
         func `get`<I>(_ key: Key<I>) -> I {
-            self.get(key, with: components)
+            self.container.get(key, with: components)
         }
         return {
             .shared

--- a/Tests/DITests/ComponentTests.swift
+++ b/Tests/DITests/ComponentTests.swift
@@ -166,4 +166,32 @@ final class ComponentTests: XCTestCase {
         child.bind("Overridden", forKey: .name)
         XCTAssertEqual(child.message(), "I'm Overridden, age=42")
     }
+
+    enum GetWithoutProvideAnnotation {
+        @Component(root: true) struct RootComponent {
+            @Provides(.name) var name: String = "Root"
+
+            var description: String {
+                return get(.name)
+            }
+
+            @Provides(.message) func message() -> String {
+                return description
+            }
+        }
+
+        @Component struct ChildComponent {
+            @Provides(.name) var name: String = "Child"
+
+            func message() -> String {
+                return get(.message)
+            }
+        }
+    }
+
+    func testGetWithoutProvideAnnotation() {
+        let root = GetWithoutProvideAnnotation.RootComponent()
+        let child = GetWithoutProvideAnnotation.ChildComponent(parent: root)
+        XCTAssertEqual(child.message(), "Child")
+    }
 }


### PR DESCRIPTION
Remove implementation introduced in https://github.com/sidepelican/swift-di/pull/2 .

Because there was a problem in the edge case and also because there is no performance problem with the method using TaskLocal.